### PR TITLE
docs: document the v1 release model

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,9 +2,23 @@
 
 This file is an index. Authoritative, modular instructions live under `./instructions/` to prevent divergence.
 
+## TODO: migrate this instruction set to Claude Code
+
+**This layout (`.github/copilot-instructions.md` + `.github/instructions/*.instructions.md` with
+`applyTo:` frontmatter) is GitHub Copilot's convention. The project now uses Claude Code, which does
+not read these files automatically** — there is no `CLAUDE.md` or `AGENTS.md` at the repo root, so
+the content below is currently invisible to the agent actually doing the work.
+
+The content itself is still correct and worth keeping; only the delivery mechanism is wrong. Migrate
+it — e.g. a root `CLAUDE.md`/`AGENTS.md` that owns or imports these modules — and then decide whether
+the Copilot-shaped files stay as a mirror or are removed. Until that happens, treat this set as
+documentation a human must point the agent at, not as instructions that load on their own.
+
 ## Instruction Modules
 
 - **[Overview](./instructions/01-overview.instructions.md)** - High-level map for AI agents. Read this first, then jump to specialized files.
 - **[Code Quality](./instructions/02-codeQuality.instructions.md)** - TypeScript, Tailwind, Astro, React, UI components
+- **[Design System](./instructions/03-designSystem.instructions.md)** - Design system tokens and guidelines
+- **[Release Process](./instructions/04-releaseProcess.instructions.md)** - Branch model, which branch publishes, PR targets, release gates
 
 For complete details, always refer to the specialized instruction files linked above.

--- a/.github/instructions/01-overview.instructions.md
+++ b/.github/instructions/01-overview.instructions.md
@@ -7,6 +7,7 @@ applyTo: "**/*"
 Purpose: High-level map for AI agents working in this repo. Read this first, then jump to specialized files:
 - **[Code Quality](./02-codeQuality.instructions.md)** - TypeScript, Tailwind, Astro, React, UI components
 - **[Design System](./03-designSystem.instructions.md)** - Design system tokens and guidelines
+- **[Release Process](./04-releaseProcess.instructions.md)** - Branch model, which branch publishes, PR targets, release gates
 
 ## Stack Snapshot
 - Astro 5.15.8

--- a/.github/instructions/04-releaseProcess.instructions.md
+++ b/.github/instructions/04-releaseProcess.instructions.md
@@ -1,0 +1,62 @@
+---
+applyTo: "**/*"
+---
+
+# Release Process Instructions
+
+Purpose: state which branch publishes to production, where work lands, and what the v1 release
+event is. Read this before opening any pull request.
+
+## CRITICAL: `main` is production
+
+**`main` is the Vercel Production Branch. Anything merged into `main` is live on
+https://www.chrobok.dev immediately.**
+
+Until the v1 cutover, `main` serves only the "Work in progress…" placeholder. Do **not** target a
+pull request at `main` while v1 is being built — doing so publishes a partial page to the live site.
+
+Note that GitHub's default branch is `development`, not `main`. These are two independent settings:
+GitHub's default branch decides where new PRs are pointed by default; Vercel's Production Branch
+decides what gets published. Never reason about one from the other.
+
+## Branch model
+
+| Branch | Role | Deploys to |
+| --- | --- | --- |
+| `main` | Production | https://www.chrobok.dev |
+| `development` | Integration — GitHub default branch | Vercel branch **Preview** (stable per-branch URL) |
+| `(feat\|fix\|chore\|docs)/…` | Feature branches | Vercel per-commit Preview |
+
+Flow:
+
+1. Branch off `development`. The branch name must satisfy `validate-branch-name` (enforced by
+   `.husky/pre-commit`): `main`, `master`, `development`, or `(feat|fix|chore|docs)/…`.
+2. Open the PR against **`development`**. Review it on the branch preview URL.
+3. Merge into `development`. This rebuilds the `development` preview and leaves production
+   untouched.
+4. The single `development` → `main` PR is the v1 release event (roadmap S-08,
+   `v1-production-cutover`). It happens once, after every slice has landed.
+
+## Constraints discovered in research
+
+- **The cutover PR must be squash or rebase.** `main` has `required_linear_history: true`, so
+  GitHub rejects a merge commit. Choose "Squash and merge" or "Rebase and merge" on the
+  `development` → `main` PR.
+- **`main` requires a PR.** Force-push and branch deletion are blocked; direct pushes are rejected.
+  `required_approving_review_count` is 0, so a solo approval is not needed — but the PR is.
+- **`yarn build` runs `astro check` before `astro build`.** A type error therefore fails the Vercel
+  deploy instead of shipping. This is a real safety net; do not "simplify" the `build` script by
+  dropping `astro check`.
+- **`development` is intentionally unprotected.** Required status checks are attached there by
+  roadmap item F-03 (`inspection-gate`). Declaring required checks before the workflows exist would
+  block every PR indefinitely, because GitHub waits forever on a check name that never reports.
+- **There is no `.github/workflows/` directory and no `vercel.json`.** Vercel infers the framework
+  from `astro` and the package manager from `yarn.lock`. Server-side PR gating is F-03's job, not
+  something to add ad hoc.
+
+## Local gates
+
+`.husky/pre-commit` runs `validate-branch-name` → `tsc --noEmit` → `lint-staged`.
+`.husky/commit-msg` runs commitlint, so commit messages must be Conventional Commits.
+
+These are local-only and bypassable with `--no-verify`. Do not bypass them.

--- a/context/changes/v1-release-staging/change.md
+++ b/context/changes/v1-release-staging/change.md
@@ -1,7 +1,7 @@
 ---
 change_id: v1-release-staging
 title: V1 release staging
-status: planned
+status: implementing
 created: 2026-07-23
 updated: 2026-07-23
 archived_at: null
@@ -10,3 +10,39 @@ archived_at: null
 ## Notes
 
 <!-- Free-form notes for this change: links, ad-hoc context, decisions that don't belong in research/frame/plan. -->
+
+### Phase 1 — observed release topology (2026-07-23)
+
+**Vercel Production Branch — observed pre-change value: `main`. No edit was required.**
+
+The plan flagged this as the load-bearing unknown: if the Production Branch had been `development`,
+every merge to `development` would already have been publishing live to chrobok.dev. It was not.
+
+Evidence (GitHub Deployments API, `gh api repos/Pokerek/website-astro/deployments`), which records the
+environment Vercel targets for each ref:
+
+| Ref | Branch | Vercel environment |
+| --- | --- | --- |
+| `5a9b9ce` (`docs: add roadmap v1`) | tip of `origin/main` | **Production** |
+| `c5b902e` (`feat: add husky config (#12)`) | tip of `origin/development` | **Preview** |
+| `6b63754` (`docs: add plan for v1-release-staging`) | `docs/v1-release-staging` | **Preview** |
+
+`development` produced a Preview, not a Production, deployment. Production Branch is therefore `main`,
+even though GitHub's default branch is `development` — the two settings are independent, as expected.
+
+**Consequence:** PR #12 was *not* a production release. The roadmap's F-02 risk framing was
+precautionary rather than understated, and no partial-page window was ever open.
+
+**GitHub protection, confirmed intact:**
+
+- `main` — PR required (`required_approving_review_count: 0`), `required_linear_history: true`,
+  `allow_force_pushes: false`, `allow_deletions: false`.
+- `development` — unprotected; the protection endpoint returns HTTP 404, which is the intended state
+  until F-03 (`inspection-gate`) attaches required status checks.
+
+**Production baseline (pre-Phase-3 merge), captured 2026-07-23:**
+
+- `HTTP/2 200`, serves `Work in progress...`
+- `etag: "3ed38505cf3185439ceea33a74be45ab"`
+- `last-modified: Wed, 22 Jul 2026 15:13:42 GMT`
+- HTML `shasum`: `34695f98d998730b2786a5fbeeab733c8abc44e1`

--- a/context/changes/v1-release-staging/change.md
+++ b/context/changes/v1-release-staging/change.md
@@ -40,6 +40,19 @@ precautionary rather than understated, and no partial-page window was ever open.
 - `development` — unprotected; the protection endpoint returns HTTP 404, which is the intended state
   until F-03 (`inspection-gate`) attaches required status checks.
 
+### Follow-up out of scope for this change
+
+**The `.github/instructions/` set targets GitHub Copilot, but the project now uses Claude Code.**
+Raised during Phase 2 manual verification. The `copilot-instructions.md` +
+`*.instructions.md` + `applyTo:` frontmatter layout is Copilot's convention; Claude Code does not
+load it, and there is no `CLAUDE.md`/`AGENTS.md` at the repo root — so all four modules, including
+the new release-process one, are currently invisible to the agent doing the work.
+
+Decision for this change: keep the module where it is (it follows the existing convention and the
+content is correct), and record the gap rather than silently expand F-02's scope into an
+instruction-system migration. A TODO block at the top of `.github/copilot-instructions.md` states
+the problem and the fix. The migration itself wants its own change.
+
 **Production baseline (pre-Phase-3 merge), captured 2026-07-23:**
 
 - `HTTP/2 200`, serves `Work in progress...`

--- a/context/changes/v1-release-staging/change.md
+++ b/context/changes/v1-release-staging/change.md
@@ -1,0 +1,12 @@
+---
+change_id: v1-release-staging
+title: V1 release staging
+status: planned
+created: 2026-07-23
+updated: 2026-07-23
+archived_at: null
+---
+
+## Notes
+
+<!-- Free-form notes for this change: links, ad-hoc context, decisions that don't belong in research/frame/plan. -->

--- a/context/changes/v1-release-staging/plan-brief.md
+++ b/context/changes/v1-release-staging/plan-brief.md
@@ -1,0 +1,68 @@
+# V1 Release Staging — Plan Brief
+
+> Full plan: `context/changes/v1-release-staging/plan.md`
+
+## What & Why
+
+Roadmap item **F-02**. The v1 release is deliberately a single cutover: all seven sections ship at once, and no recruiter ever sees a partial page. That strategy only works if merging v1 work does *not* publish to `chrobok.dev` — so this change establishes `main` as production (still serving the placeholder) and `development` as the integration branch behind a Vercel preview, then **proves** it with a live merge.
+
+## Starting Point
+
+More is already in place than the roadmap records, and one recorded fact is wrong. `development` already exists, is the **GitHub default branch**, and already receives PRs (#12; #8–#11 went to `main`). `main` is the only protected branch — PR required, linear history, no force-push. `.github/workflows/` does not exist (the roadmap says "empty"), so nothing gates a PR server-side; the husky hooks that do run (`tsc --noEmit`, lint-staged, commitlint) are bypassable with `--no-verify`. There is no `vercel.json` — deployment is dashboard-only.
+
+The critical gap: the roadmap asserts "merging to `main` publishes", but **nobody has verified this**. Vercel's Production Branch is fixed at import time and is *not* updated when GitHub's default branch changes — and the default is now `development`. If Vercel is pointed at `development`, every merge is already a live release and PR #12 already shipped to production.
+
+## Desired End State
+
+`main` publishes to `chrobok.dev` and keeps serving "Work in progress…" until S-08. The five content slices merge into `development` and are reviewed on a stable Vercel branch preview. The branch model is written down where an agent will find it, the roadmap's stale baseline is corrected, and a real merge has been *observed* to rebuild the preview while leaving production untouched.
+
+## Key Decisions Made
+
+| Decision | Choice | Why (1 sentence) |
+| --- | --- | --- |
+| Vercel Production Branch | `main` | Matches the one-pass cutover, and `main` already carries the full protection ruleset. |
+| Branch model | feature → `development` → `main` at cutover | Documents the model already in flight (PR #12) rather than inventing a new one. |
+| Reviewable URL | Vercel's stable `development` branch preview | Zero config, no DNS, no `noindex` handling to own. |
+| Protection on `development` | None — harden `main` only | `development` is staging; F-03 will add protection when it has status checks to attach. |
+| Repo artifacts | Documentation only | Vercel already infers Astro + yarn correctly; a pinned `vercel.json` would silently override `package.json`. |
+| Proof of insulation | Live smoke test on this change's own docs commit | Tests the real mechanism at zero risk — a docs commit can't damage the site even if the wiring is inverted. |
+
+## Scope
+
+**In scope:** Verifying and correcting the Vercel Production Branch; confirming `main`'s protection; a new `.github/instructions/04-releaseProcess.instructions.md` module plus index wiring; correcting the roadmap's baseline; a live merge smoke test.
+
+**Out of scope:** Any CI workflow file (that is F-03); branch protection on `development` (F-03); `vercel.json`; a custom staging subdomain; any content change — `index.astro` keeps the placeholder until S-08.
+
+## Architecture / Approach
+
+```
+feat|fix|chore|docs/*  ──PR──▶  development  ──▶  Vercel Preview (stable branch URL)
+                                     │
+                                     └──PR (squash/rebase, S-08 only)──▶  main  ──▶  chrobok.dev
+```
+
+Observe → document → prove. Phase 1 precedes Phase 2 because if Vercel is pointed at `development`, Phase 2's own merge would be a production deploy. Phase 3 reuses Phase 2's docs commit as its test payload rather than inventing a throwaway one.
+
+## Phases at a Glance
+
+| Phase | What it delivers | Key risk |
+| --- | --- | --- |
+| 1. Observe & correct topology | The real Vercel/GitHub state, recorded; Production Branch = `main` | The setting may be inverted — if so, production was already exposed and this is urgent, not routine |
+| 2. Document the release model | Release-process instruction module, index wiring, corrected roadmap baseline | Docs that drift from dashboard settings nothing in the repo enforces |
+| 3. Prove insulation | An observed merge: preview rebuilds, production does not | Both branches build identical output, so the test must key on build activity, not page content |
+
+**Prerequisites:** Vercel dashboard access (the CLI is not installed); `gh` authenticated as `Pokerek` (confirmed).
+**Estimated effort:** ~1 session; docs-only diff plus two dashboard checks and one merge.
+
+## Open Risks & Assumptions
+
+- **The Vercel Production Branch value is unknown until Phase 1.** If it is `development`, PR #12 already published to production and the roadmap's risk framing for F-02 was understated.
+- **Nothing in the repo enforces the topology.** By choice — if the dashboard setting changes later, only the docs would disagree, silently. F-03 partially closes this.
+- **`required_linear_history` on `main`** means the S-08 cutover PR must be squash or rebase; a merge commit will be rejected at the worst possible moment if not known in advance.
+- **`development` stays unprotected**, so a direct push can bypass the PR review step the model assumes.
+
+## Success Criteria (Summary)
+
+- A merge into `development` produces a Vercel **Preview** deployment and **no** Production deployment — observed, not assumed.
+- `chrobok.dev` is byte-identical before and after that merge and still shows "Work in progress…".
+- A stable preview URL is recorded that S-01 through S-07 can be reviewed on.

--- a/context/changes/v1-release-staging/plan.md
+++ b/context/changes/v1-release-staging/plan.md
@@ -1,0 +1,346 @@
+# V1 Release Staging Implementation Plan
+
+## Overview
+
+Establish — and *prove* — that v1 work can merge and deploy to a reviewable URL without `chrobok.dev` ever showing a partial page. `main` stays the production branch serving the "Work in progress…" placeholder until the S-08 cutover; `development` accumulates the five content slices behind a Vercel branch preview.
+
+This is roadmap item **F-02** (`v1-release-staging`). It is the mechanism the north star S-08 depends on: without it, the auto-deploy-on-merge behaviour publishes every partial section straight to production, contradicting the deliberately-chosen one-pass release.
+
+The change is deliberately small in the repo and large in *certainty*. Most of the machinery already exists; what does not exist is any evidence that it behaves the way the roadmap claims.
+
+## Current State Analysis
+
+Researched 2026-07-23 against the live repo and the GitHub API.
+
+**Branch topology — already partly in place, undocumented:**
+
+- Two long-lived branches exist: `main` and `development`. Working tree is on `development`, clean.
+- `development` is the **GitHub default branch** (`gh repo view` → `defaultBranchRef.name = development`).
+- `development` is exactly one commit ahead of `main` (`c5b902e feat: add husky config (#12)`); `main` has nothing `development` lacks. Application source is byte-identical on both.
+- PR history shows a recent shift: #8–#11 all targeted `main`; #12 targeted `development`. The integration-branch model has already started, without being written down anywhere.
+
+**Protection — asymmetric:**
+
+- `main` is protected: PR required (`required_approving_review_count: 0`), `required_linear_history: true`, `allow_force_pushes: false`, `allow_deletions: false`, `required_conversation_resolution: true`, `enforce_admins: false`.
+- `development` has **no protection at all** (API returns 404 "Branch not protected").
+
+**CI and gating:**
+
+- `.github/workflows/` **does not exist**. The roadmap baseline says it is "empty" — it is absent. Nothing runs server-side on any PR.
+- Local gates exist and are real but bypassable: `.husky/pre-commit` runs `npx validate-branch-name` → `npx tsc --noEmit` → `npx lint-staged`; `.husky/commit-msg` runs commitlint. All are skippable with `git commit --no-verify` and none run on a PR.
+- `package.json:build` is `astro check && astro build`, so any Vercel build already type-checks as a side effect. `validate-branch-name` pattern permits `main`, `master`, `development`, and `(feat|fix|chore|docs)/…`.
+
+**Deployment:**
+
+- No `vercel.json` and no `.vercel/` directory. Vercel is wired purely through the dashboard Git integration. The `vercel` CLI is not installed locally.
+- Vercel infers the framework from `astro`, and the package manager from `yarn.lock` (`packageManager: yarn@1.22.22` is also declared).
+
+**The load-bearing unknown this plan exists to close:**
+
+The roadmap baseline asserts "Merging to `main` publishes with no gate in front of it." **This was never verified and may be inverted.** Vercel's Production Branch is a dashboard setting fixed at project-import time; it is *not* updated when GitHub's default branch changes. Since GitHub's default is now `development`, there are two possible live states with opposite consequences:
+
+- Production Branch = `main` → merges to `development` already produce previews, and F-02 is largely already true but undocumented and unproven.
+- Production Branch = `development` → **every merge to `development` is already publishing live to chrobok.dev**, which is exactly the failure this foundation exists to prevent. PR #12 would then already have been a production release.
+
+This cannot be resolved from the repo. It is resolved in Phase 1 by direct observation.
+
+## Desired End State
+
+1. Vercel's Production Branch is `main`, confirmed by observation rather than assumption.
+2. `main` remains protected with its current ruleset; `development` remains unprotected by deliberate choice.
+3. The branch model and release rule are written down in the repo where both a human and an AI agent will find them.
+4. The roadmap's baseline no longer contains claims contradicted by observation.
+5. A real merge into `development` has been observed to rebuild the branch preview while leaving `chrobok.dev` unchanged.
+
+Verified by: the Phase 3 smoke test, which is the only step that tests the mechanism end-to-end with a live merge.
+
+### Key Discoveries:
+
+- `development` is already the default branch and already receives PRs (#12) — this change documents and hardens an in-flight model rather than introducing one.
+- `main` already carries the entire production gate (`main` protection ruleset) — no new protection work is required.
+- `required_linear_history: true` on `main` means the S-08 cutover PR must be **squash or rebase**; a merge commit will be rejected. Worth knowing now, not at cutover.
+- `package.json:build` already runs `astro check`, so a broken type reaching production fails the Vercel build rather than deploying — a meaningful safety net that exists by accident and should be recorded so nobody removes it.
+- `.github/copilot-instructions.md` is an index that is already out of date: it lists two modules while `01-overview.instructions.md` links three (Design System is missing from the index). Adding a fourth module must not repeat that mistake.
+
+## What We're NOT Doing
+
+- **No CI workflow file.** `.github/workflows/` stays absent. Build/type/lint gating on PRs is roadmap item **F-03** (`inspection-gate`), which is explicitly sequenced after F-02. Pulling it in here would merge two roadmap items.
+- **No branch protection on `development`.** Deferred to F-03, which will need protection there anyway as the attachment point for required status checks. Declaring required checks before those checks exist would block every PR indefinitely — GitHub waits forever on a check name that never reports.
+- **No `vercel.json`.** Vercel already infers framework and package manager correctly, and a pinned `buildCommand` would silently override `package.json` the next time the build script changes.
+- **No custom staging subdomain.** Vercel's auto-generated stable branch URL is used as-is; no DNS work and no `noindex` handling to own.
+- **No content changes.** `src/pages/index.astro` keeps the placeholder — deleting it is S-08's job.
+- **No changes to the husky hooks, eslint config, or `package.json` scripts.**
+
+## Implementation Approach
+
+Observe first, then document, then prove. The ordering is not cosmetic:
+
+Phase 1 must precede Phase 2 because if Vercel's Production Branch turns out to be `development`, then Phase 2's own documentation commit — merged into `development` — would itself be a production deploy. The settings have to be correct before *anything* merges.
+
+Phase 3 deliberately reuses Phase 2's commit as its test payload instead of inventing a throwaway one. A docs-only commit is the ideal probe: it changes the deployed output not at all, so if the wiring is inverted, the smoke test reveals it at zero cost to the live site.
+
+## Critical Implementation Details
+
+**Timing & lifecycle.** Vercel's Production Branch setting and GitHub's default branch are independent. Changing GitHub's default branch to `development` (already done, at some earlier point) did **not** repoint Vercel. Any reasoning that treats "default branch" and "production branch" as the same thing is wrong here, and that conflation is the most likely source of the roadmap's unverified claim.
+
+**Debug & observability.** The two branches currently build byte-identical output, so comparing rendered HTML cannot distinguish which branch is serving production. The smoke test therefore has to key on *build activity* (does a new deployment appear, and against which branch) rather than on page content.
+
+## Phase 1: Observe and correct the release topology
+
+### Overview
+
+Establish the actual live state of the Vercel and GitHub settings, record it, and correct it if it does not match the intended topology. No repo files change in this phase — it is observation plus at most one dashboard edit.
+
+### Changes Required:
+
+#### 1. Vercel Production Branch (dashboard — outside the repo)
+
+**File**: none — Vercel dashboard, Project → Settings → Git
+
+**Intent**: Determine what the Production Branch is actually set to, and set it to `main` if it is not. This closes the unknown that makes the roadmap's baseline unverifiable, and is the single setting the entire one-pass-release strategy rests on.
+
+**Contract**: Production Branch = `main`. All other branches, including `development`, produce Preview deployments. Record the *observed pre-change value* — it is needed for Phase 2's roadmap correction and determines whether PR #12 was already a production release.
+
+#### 2. GitHub protection state (dashboard/API — outside the repo)
+
+**File**: none — GitHub → Settings → Branches, or `gh api repos/Pokerek/website-astro/branches/main/protection`
+
+**Intent**: Confirm `main`'s existing ruleset is intact and that `development` is still unprotected, so Phase 3's smoke test runs against a known configuration rather than a drifting one.
+
+**Contract**: `main` — PR required, `required_linear_history: true`, force-push and deletion blocked. `development` — no protection (404 from the protection endpoint is the expected, correct result).
+
+#### 3. Scratch record of observed state
+
+**File**: `context/changes/v1-release-staging/change.md` (`## Notes` section)
+
+**Intent**: Write down what was observed before anything was changed, so Phase 2 documents reality and the roadmap correction is grounded in evidence rather than in this plan's expectations.
+
+**Contract**: Notes gain the observed pre-change Production Branch value, whether it was edited, and the date of observation.
+
+### Success Criteria:
+
+#### Automated Verification:
+
+- `main` protection is intact: `gh api repos/Pokerek/website-astro/branches/main/protection` returns `required_linear_history.enabled: true` and `allow_force_pushes.enabled: false`
+- `development` is unprotected: `gh api repos/Pokerek/website-astro/branches/development/protection` returns HTTP 404
+- Working tree is clean apart from `change.md`: `git status --short`
+
+#### Manual Verification:
+
+- Vercel Project → Settings → Git shows Production Branch = `main`
+- The pre-change observed value is recorded in `change.md` Notes, including whether an edit was required
+- `https://www.chrobok.dev` still serves the "Work in progress…" placeholder and returns HTTP 200
+
+**Implementation Note**: After completing this phase and all automated verification passes, pause here for manual confirmation from the human that the manual testing was successful before proceeding to the next phase. If the observed Production Branch was `development`, flag it explicitly — it means PR #12 already published to production and the roadmap's risk framing was understated.
+
+---
+
+## Phase 2: Document the release model in the repo
+
+### Overview
+
+Write the branch model and release rule where both a human and an AI agent will find them, and correct the two roadmap baseline claims that observation has now contradicted. Docs-only — no source, config, or dependency changes.
+
+### Changes Required:
+
+#### 1. Release-process instruction module
+
+**File**: `.github/instructions/04-releaseProcess.instructions.md` (new)
+
+**Intent**: Give agents and future-you an authoritative statement of which branch publishes, where slice PRs land, and what the v1 release event is — so nobody targets a PR at `main` mid-build and ships a partial page.
+
+**Contract**: Follows the existing module convention — YAML frontmatter with `applyTo: "**/*"`, matching the sibling files. Content covers: `main` = production (serves chrobok.dev), `development` = integration (Vercel branch preview), feature branches follow the `validate-branch-name` pattern `(feat|fix|chore|docs)/…` and PR into `development`, and the single `development` → `main` PR is the S-08 cutover. Records two constraints discovered in research: the cutover PR must be squash or rebase because `main` enforces linear history, and `yarn build` runs `astro check` so a type error fails the deploy rather than shipping.
+
+#### 2. Instruction index
+
+**File**: `.github/copilot-instructions.md`
+
+**Intent**: Register the new module in the index so it is discoverable through the documented entry point.
+
+**Contract**: Add a `- **[Release Process](./instructions/04-releaseProcess.instructions.md)**` bullet to the Instruction Modules list. While here, add the missing `- **[Design System](./instructions/03-designSystem.instructions.md)**` entry — the index currently lists two modules while `01-overview.instructions.md` links three, and leaving that gap while adding a fourth entrenches the divergence the file's own header warns against.
+
+#### 3. Overview cross-reference
+
+**File**: `.github/instructions/01-overview.instructions.md`
+
+**Intent**: The overview is the documented "read this first" file and already links the specialised modules; the release module has to be reachable from it or agents will not find it.
+
+**Contract**: Add the release-process module to the module list at the top of the file, alongside Code Quality and Design System.
+
+#### 4. Roadmap baseline correction
+
+**File**: `context/foundation/roadmap.md`
+
+**Intent**: Two baseline claims are contradicted by research and one is now resolved, and leaving them stale would misinform every downstream slice that reads the baseline as ground truth.
+
+**Contract**: In the `## Baseline` section's Deploy/infra bullet: replace "`.github/workflows/` is empty" with the accurate statement that it is absent, and replace the unverified "Merging to `main` publishes with no gate in front of it" with the Phase 1 observed behaviour. Add the branch topology fact the baseline omits entirely — that `development` exists, is the GitHub default branch, and is already receiving PRs. Update F-02's `Status:` from `ready` to reflect the work being in flight, and update the frontmatter `updated:` date.
+
+#### 5. Change record
+
+**File**: `context/changes/v1-release-staging/change.md`
+
+**Intent**: Keep the change identity file honest about status.
+
+**Contract**: `status: planned` → `in-progress` (or the project's equivalent in-flight value), `updated: 2026-07-23`.
+
+### Success Criteria:
+
+#### Automated Verification:
+
+- Type check passes: `npx tsc --noEmit`
+- Lint passes: `yarn lint`
+- Build passes: `yarn build`
+- Formatting is clean: `npx prettier --check "**/*.md"`
+- The new module exists: `test -f .github/instructions/04-releaseProcess.instructions.md`
+- Every module linked from the index resolves to a real file (no broken relative links in `.github/copilot-instructions.md`)
+- No source or config files were touched: `git diff --name-only main...HEAD` lists only `.github/**/*.md` and `context/**/*.md`
+
+#### Manual Verification:
+
+- The release module states unambiguously which branch publishes to chrobok.dev — a reader who knows nothing about this change can answer that question from it alone
+- The roadmap baseline no longer contains the "`.github/workflows/` is empty" or unverified-publish claims
+- Commit message passes commitlint (conventional format, `docs:` type) and the branch name satisfies `validate-branch-name`
+
+**Implementation Note**: After completing this phase and all automated verification passes, pause here for manual confirmation from the human that the manual testing was successful before proceeding to the next phase.
+
+---
+
+## Phase 3: Prove the insulation with a live smoke test
+
+### Overview
+
+Merge Phase 2's docs-only commit into `development` through a PR and observe the two things that must be true: the branch preview rebuilds, and production does not. This is the step that converts the whole foundation from a configured intention into an observed fact.
+
+### Changes Required:
+
+#### 1. Pull request into `development`
+
+**File**: none — GitHub PR
+
+**Intent**: Exercise the real merge path the five content slices will use, with a payload that cannot damage the live site even if the wiring turns out to be inverted.
+
+**Contract**: Base `development`, head the Phase 2 feature branch (`docs/…` per the `validate-branch-name` pattern). Merged, not squashed-into-`main`; `main` is not touched in this phase.
+
+#### 2. Production baseline capture (before the merge)
+
+**File**: none — captured to the scratchpad, not the repo
+
+**Intent**: Because both branches build identical output, "production is unchanged" needs a *before* value to compare against. Without capturing it first, the smoke test cannot distinguish "production didn't deploy" from "production deployed the same thing".
+
+**Contract**: Record, before merging, the production response's `etag`/`last-modified` and `x-vercel-id` headers plus a hash of the served HTML. Compare the same values after the merge. A changed `age`/`x-vercel-cache` value is expected noise; a changed `etag` or `last-modified` on the HTML document is a failure signal.
+
+### Success Criteria:
+
+#### Automated Verification:
+
+- Production still responds 200: `curl -sSI https://www.chrobok.dev | head -1`
+- Production HTML is unchanged from the pre-merge capture: `curl -sS https://www.chrobok.dev | shasum` matches the baseline hash
+- Production `last-modified` / `etag` headers match the pre-merge capture
+- `main` did not move: `git fetch origin && git rev-parse origin/main` equals its pre-merge value
+- `development` contains the docs commit: `git log --oneline origin/development -1`
+
+#### Manual Verification:
+
+- Vercel shows a **Preview** deployment (not Production) for the `development` merge, with the branch shown as `development`
+- The `development` branch preview URL loads and serves the placeholder page — confirming the preview environment actually builds this project successfully
+- No new **Production** deployment appears in Vercel's deployment list for this merge
+- `https://www.chrobok.dev` still shows "Work in progress…" in a real browser
+- The stable `development` preview URL is recorded in `change.md` Notes, so S-01 through S-07 have a known review target
+
+**Implementation Note**: This is the final phase. If any production-side check fails, stop — the topology is inverted and S-01 must not start. Treat that as a Phase 1 regression, not a Phase 3 defect.
+
+---
+
+## Testing Strategy
+
+There is no application code in this change, so the testing strategy is observational rather than unit-based.
+
+### Unit Tests:
+
+- None. No source files change, and the repo has no test runner (recorded in the roadmap baseline as deliberate for v1).
+
+### Integration Tests:
+
+- Phase 3's smoke test *is* the integration test: a real PR through the real merge path against the real deployment platform.
+
+### Manual Testing Steps:
+
+1. Before merging Phase 2, capture the production baseline: response headers and an HTML hash for `https://www.chrobok.dev`.
+2. Open and merge the Phase 2 PR into `development`.
+3. Watch the Vercel deployment list — confirm exactly one new deployment appears and it is labelled Preview against branch `development`.
+4. Load the `development` branch preview URL; confirm it builds and serves the placeholder.
+5. Re-fetch production; confirm status, hash and `last-modified` are identical to the baseline.
+6. Confirm in a browser that `chrobok.dev` still shows "Work in progress…".
+
+## Performance Considerations
+
+None. No runtime code changes, no added dependencies, no change to the build. `yarn build` continues to run `astro check && astro build`.
+
+## Migration Notes
+
+No data or schema. The only migration is procedural, and it is already partly complete: PRs #8–#11 targeted `main` and #12 targeted `development`. From this change onward, `main` receives exactly one PR before the cutover — the S-08 promotion — and every other v1 PR targets `development`.
+
+If Phase 1 finds Vercel's Production Branch set to `development`, note that PR #12 was already published to production. That has no content consequence (both branches serve identical output) but it does mean the window in which a partial page could have shipped was already open, and the roadmap's risk framing for F-02 was understated rather than precautionary.
+
+## References
+
+- Roadmap item: `context/foundation/roadmap.md` — F-02 (`v1-release-staging`), Streams table (Stream B), Baseline
+- PRD: `context/foundation/prd.md` — §Success Criteria (primary), §Guardrails ("the site survives a technical inspection")
+- Downstream dependency: F-03 (`inspection-gate`) owns CI gating and `development` branch protection
+- North star: S-08 (`v1-production-cutover`) is the single `development` → `main` promotion this foundation enables
+- Existing instruction modules: `.github/instructions/01-overview.instructions.md`, `.github/copilot-instructions.md`
+- Local gates: `.husky/pre-commit`, `.husky/commit-msg`, `package.json` (`build`, `lint`, `validate-branch-name`)
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles. See `references/progress-format.md`.
+
+### Phase 1: Observe and correct the release topology
+
+#### Automated
+
+- [ ] 1.1 `main` protection intact (`required_linear_history`, no force-push)
+- [ ] 1.2 `development` unprotected (protection endpoint returns 404)
+- [ ] 1.3 Working tree clean apart from `change.md`
+
+#### Manual
+
+- [ ] 1.4 Vercel Production Branch = `main`
+- [ ] 1.5 Pre-change observed value recorded in `change.md` Notes
+- [ ] 1.6 `https://www.chrobok.dev` serves the placeholder and returns 200
+
+### Phase 2: Document the release model in the repo
+
+#### Automated
+
+- [ ] 2.1 Type check passes (`npx tsc --noEmit`)
+- [ ] 2.2 Lint passes (`yarn lint`)
+- [ ] 2.3 Build passes (`yarn build`)
+- [ ] 2.4 Markdown formatting clean (`npx prettier --check "**/*.md"`)
+- [ ] 2.5 `.github/instructions/04-releaseProcess.instructions.md` exists
+- [ ] 2.6 All index links in `copilot-instructions.md` resolve to real files
+- [ ] 2.7 Diff touches only `.github/**/*.md` and `context/**/*.md`
+
+#### Manual
+
+- [ ] 2.8 Release module unambiguously names the publishing branch
+- [ ] 2.9 Roadmap baseline no longer contains the stale workflows/publish claims
+- [ ] 2.10 Commit message passes commitlint; branch name passes `validate-branch-name`
+
+### Phase 3: Prove the insulation with a live smoke test
+
+#### Automated
+
+- [ ] 3.1 Production responds 200
+- [ ] 3.2 Production HTML hash matches pre-merge baseline
+- [ ] 3.3 Production `last-modified` / `etag` match pre-merge baseline
+- [ ] 3.4 `origin/main` unmoved
+- [ ] 3.5 `origin/development` contains the docs commit
+
+#### Manual
+
+- [ ] 3.6 Vercel shows a Preview deployment for branch `development`
+- [ ] 3.7 The `development` preview URL builds and serves the placeholder
+- [ ] 3.8 No new Production deployment appeared for this merge
+- [ ] 3.9 `chrobok.dev` still shows "Work in progress…" in a browser
+- [ ] 3.10 Stable `development` preview URL recorded in `change.md` Notes

--- a/context/changes/v1-release-staging/plan.md
+++ b/context/changes/v1-release-staging/plan.md
@@ -299,33 +299,33 @@ If Phase 1 finds Vercel's Production Branch set to `development`, note that PR #
 
 #### Automated
 
-- [x] 1.1 `main` protection intact (`required_linear_history`, no force-push)
-- [x] 1.2 `development` unprotected (protection endpoint returns 404)
-- [x] 1.3 Working tree clean apart from `change.md`
+- [x] 1.1 `main` protection intact (`required_linear_history`, no force-push) — fdd1fcc
+- [x] 1.2 `development` unprotected (protection endpoint returns 404) — fdd1fcc
+- [x] 1.3 Working tree clean apart from `change.md` — fdd1fcc
 
 #### Manual
 
-- [x] 1.4 Vercel Production Branch = `main`
-- [x] 1.5 Pre-change observed value recorded in `change.md` Notes
-- [x] 1.6 `https://www.chrobok.dev` serves the placeholder and returns 200
+- [x] 1.4 Vercel Production Branch = `main` — fdd1fcc
+- [x] 1.5 Pre-change observed value recorded in `change.md` Notes — fdd1fcc
+- [x] 1.6 `https://www.chrobok.dev` serves the placeholder and returns 200 — fdd1fcc
 
 ### Phase 2: Document the release model in the repo
 
 #### Automated
 
-- [ ] 2.1 Type check passes (`npx tsc --noEmit`)
-- [ ] 2.2 Lint passes (`yarn lint`)
-- [ ] 2.3 Build passes (`yarn build`)
-- [ ] 2.4 Markdown formatting clean (`npx prettier --check "**/*.md"`)
-- [ ] 2.5 `.github/instructions/04-releaseProcess.instructions.md` exists
-- [ ] 2.6 All index links in `copilot-instructions.md` resolve to real files
-- [ ] 2.7 Diff touches only `.github/**/*.md` and `context/**/*.md`
+- [x] 2.1 Type check passes (`npx tsc --noEmit`)
+- [x] 2.2 Lint passes (`yarn lint`)
+- [x] 2.3 Build passes (`yarn build`)
+- [x] 2.4 Markdown formatting clean (`npx prettier --check "**/*.md"`)
+- [x] 2.5 `.github/instructions/04-releaseProcess.instructions.md` exists
+- [x] 2.6 All index links in `copilot-instructions.md` resolve to real files
+- [x] 2.7 Diff touches only `.github/**/*.md` and `context/**/*.md` (checked against `origin/development`, the real merge base; `main...HEAD` also shows PR #12's husky/commitlint files, which this change did not touch)
 
 #### Manual
 
-- [ ] 2.8 Release module unambiguously names the publishing branch
-- [ ] 2.9 Roadmap baseline no longer contains the stale workflows/publish claims
-- [ ] 2.10 Commit message passes commitlint; branch name passes `validate-branch-name`
+- [x] 2.8 Release module unambiguously names the publishing branch
+- [x] 2.9 Roadmap baseline no longer contains the stale workflows/publish claims
+- [x] 2.10 Commit message passes commitlint; branch name passes `validate-branch-name`
 
 ### Phase 3: Prove the insulation with a live smoke test
 

--- a/context/changes/v1-release-staging/plan.md
+++ b/context/changes/v1-release-staging/plan.md
@@ -299,15 +299,15 @@ If Phase 1 finds Vercel's Production Branch set to `development`, note that PR #
 
 #### Automated
 
-- [ ] 1.1 `main` protection intact (`required_linear_history`, no force-push)
-- [ ] 1.2 `development` unprotected (protection endpoint returns 404)
-- [ ] 1.3 Working tree clean apart from `change.md`
+- [x] 1.1 `main` protection intact (`required_linear_history`, no force-push)
+- [x] 1.2 `development` unprotected (protection endpoint returns 404)
+- [x] 1.3 Working tree clean apart from `change.md`
 
 #### Manual
 
-- [ ] 1.4 Vercel Production Branch = `main`
-- [ ] 1.5 Pre-change observed value recorded in `change.md` Notes
-- [ ] 1.6 `https://www.chrobok.dev` serves the placeholder and returns 200
+- [x] 1.4 Vercel Production Branch = `main`
+- [x] 1.5 Pre-change observed value recorded in `change.md` Notes
+- [x] 1.6 `https://www.chrobok.dev` serves the placeholder and returns 200
 
 ### Phase 2: Document the release model in the repo
 

--- a/context/foundation/roadmap.md
+++ b/context/foundation/roadmap.md
@@ -3,7 +3,7 @@ project: "Chrobok.dev"
 version: 1
 status: draft
 created: 2026-07-22
-updated: 2026-07-22
+updated: 2026-07-23
 prd_version: 1
 main_goal: quality
 top_blocker: time
@@ -48,7 +48,7 @@ to recruiters at any point.
 | ID   | Change ID                 | Outcome (user can …)                                                        | Prerequisites                  | PRD refs                       | Status   |
 | ---- | ------------------------- | --------------------------------------------------------------------------- | ------------------------------ | ------------------------------ | -------- |
 | F-01 | design-system-contract    | (foundation) page skeleton + token contract settled; no ambiguity left       | —                              | §NFRs, §Guardrails             | ready    |
-| F-02 | v1-release-staging        | (foundation) v1 work merges without reaching production                      | —                              | §Success Criteria (primary)    | ready    |
+| F-02 | v1-release-staging        | (foundation) v1 work merges without reaching production                      | —                              | §Success Criteria (primary)    | in progress |
 | F-03 | inspection-gate           | (foundation) build, types and lint gate every v1 merge; inspection checklist runnable | F-02                  | §NFRs, §Guardrails             | proposed |
 | S-01 | hero-first-screen         | read name, role title, core stack and a positioning line, and reach email + CV, without scrolling | F-01, F-02   | US-01, FR-001, FR-002, FR-003  | proposed |
 | S-02 | work-proof-block          | read the commercial work with its ownership scope, numeric proof points and two-tier stack tags | F-01, F-02     | US-01, FR-004, FR-005, FR-006  | proposed |
@@ -78,7 +78,8 @@ Foundations below assume these are present and do NOT re-scaffold them.
 - **Backend / API:** absent — no routes and no adapter in `astro.config.mjs` (static output). Deliberate, per PRD §Non-Goals.
 - **Data:** absent — no schema, no migrations, no content collections. Deliberate, per PRD §Non-Goals.
 - **Auth:** absent — deliberate, per PRD §Access Control (fully public, no accounts).
-- **Deploy / infra:** partial — live on Vercel at https://www.chrobok.dev via the Git integration, but `.github/workflows/` is empty and there is no `vercel.json`. Merging to `main` publishes with no gate in front of it.
+- **Deploy / infra:** partial — live on Vercel at https://www.chrobok.dev via the Git integration, but `.github/workflows/` does not exist (there is no workflows directory at all) and there is no `vercel.json`. Vercel's Production Branch is `main` — verified 2026-07-23 against the GitHub Deployments API, which shows `origin/main` deploying to Production and `origin/development` to Preview. Merging to `main` therefore publishes straight to the live site with no server-side gate in front of it; merging to `development` does not.
+- **Branch topology:** present — two long-lived branches. `development` is the **GitHub default branch** and already receives PRs (#12 landed there; #8–#11 predate the shift and targeted `main`). `main` is protected: PR required, `required_linear_history: true`, force-push and deletion blocked. `development` is deliberately unprotected until F-03 attaches required status checks.
 - **Observability:** absent — deliberate, per PRD §Non-Goals (no analytics, no vendor accounts).
 - **Verification / testing:** absent — no test runner and no accessibility or performance check. `yarn build` runs `astro check`, and `eslint` is configured with a flat config. Recorded because all four NFRs are outside-observable properties an inspecting tech lead measures directly.
 
@@ -111,7 +112,7 @@ Foundations below assume these are present and do NOT re-scaffold them.
 - **Blockers:** —
 - **Unknowns:** —
 - **Risk:** Without it, the baseline's auto-deploy-on-merge behaviour publishes every partial section straight to chrobok.dev, which contradicts the chosen one-pass release; the risk of the foundation itself is that a long-lived branch drifts, which is bounded by the one-week window.
-- **Status:** ready
+- **Status:** in progress
 
 ### F-03: Inspection gate
 


### PR DESCRIPTION
## Summary

Foundation **F-02** (`v1-release-staging`), Phases 1–2.

- Verified the release topology by observation: Vercel's Production Branch is **`main`** (GitHub Deployments API shows `origin/main` → Production, `origin/development` → Preview). No dashboard edit was needed, and PR #12 was **not** a production release.
- Added `.github/instructions/04-releaseProcess.instructions.md` — the branch model, which branch publishes, where PRs land, and the constraints found in research (cutover PR must be squash/rebase because `main` enforces linear history; `yarn build` runs `astro check` so a type error fails the deploy).
- Registered it in the index and the overview, and added the missing Design System entry the index had dropped.
- Corrected two stale roadmap baseline claims (`.github/workflows/` is absent, not empty; the publish behaviour is now recorded from observation) and added the branch-topology bullet the baseline omitted.
- Flagged that the `.github/instructions/` set is Copilot-shaped while the project now uses Claude Code — content kept, migration recorded as follow-up.

No source, config, or dependency changes. Docs only.

## Test plan

This PR **is** the Phase 3 smoke test — a docs-only payload deliberately chosen because it changes the deployed output not at all.

- [x] `npx tsc --noEmit`
- [x] `yarn lint`
- [x] `yarn build`
- [x] `npx prettier --check "**/*.md"`
- [ ] After merge: exactly one new **Preview** deployment appears for branch `development`
- [ ] After merge: no new **Production** deployment appears
- [ ] After merge: `chrobok.dev` still returns 200 with `etag: "3ed38505cf3185439ceea33a74be45ab"` and an unchanged HTML hash

🤖 Generated with [Claude Code](https://claude.com/claude-code)