### PR TITLE
feat: settle design-system and layout contract (F-01)

### DIFF
--- a/.claude/rules/design-system.md
+++ b/.claude/rules/design-system.md
@@ -12,11 +12,37 @@ Tokens are configured in `tailwind.config.mjs` (colors, fonts, spacing) and `src
 
 ## Principles
 
-- **Fonts**: Ramaraja for headings (`font-heading`), IBM Plex Mono for body/accents (`font-body`).
+- **Fonts**: Ramaraja 700 for headings (`font-heading`), IBM Plex Mono for body/accents (`font-body`).
+  This pair is the frozen v1 typography contract — do not swap it while building sections.
 - **Colors**: token names only — `page-bg`, `element-bg`, `hover-bg`, `text-primary`, `text-secondary`,
-  `border-default` (used as `bg-page-bg`, `text-text-primary`, `border-border-default`, …).
-- **Border radius**: 0 by default — square corners, no need to specify.
+  `border-default`, `focus-ring` (used as `bg-page-bg`, `text-text-primary`, `border-border-default`, …).
+- **Border radius**: **every** named radius resolves to `0` — `rounded`, `rounded-md`, `rounded-lg`,
+  `rounded-full` are all square. Corners are never rounded in v1; don't reintroduce a rounded value.
 - **Spacing**: token scale — `p-card`, `gap-grid`, `space-y-element`, `section`, `container`.
+
+## Layout skeleton (F-01 contract)
+
+- **Container**: centered, `2rem` horizontal padding, max width `1400px` at `2xl` (Tailwind `container`).
+- **Grid**: the page skeleton is section-level, not a global two-column frame. Use the `Section` primitive
+  at `src/components/layout/Section.astro`: a semantic `<section>` with a scroll anchor plus the container.
+  Fill the `label` slot to get the `label | content` two-column layout (`md:grid-cols-section`), which
+  **collapses to a single column below `md`**; omit the `label` slot for a full-width section.
+- Sections own their own heading level and ARIA — pass headings as slot content, don't let the primitive
+  impose them.
+
+## Focus & motion
+
+- **Focus ring**: keyboard focus is handled globally by the `:focus-visible` rule in `globals.css`
+  (`ring-2 ring-offset-2`). The ring colour is the `focus-ring` token and the offset is `page-bg`, both set
+  as ring defaults in `tailwind.config.mjs`. Don't add `ring-<color>` at call sites; don't remove the ring.
+- **Motion**: `transition-colors` on hover/focus only. No fade-in, slide, scale, scroll-reveal or parallax
+  in v1 — this protects the "no layout shift after first paint" NFR.
+
+## No hard-coded values
+
+Colours, spacing, radius and ring all come from tokens — never a raw hex, px, or `border-black`. shadcn is
+configured with `cssVariables: false` (`components.json`), so generated components must be re-pointed at the
+named tokens above before they compile against anything real.
 
 ## Checklist for a new or modified `src/ui/base` component
 

--- a/components.json
+++ b/components.json
@@ -7,7 +7,7 @@
     "config": "tailwind.config.mjs",
     "css": "src/styles/globals.css",
     "baseColor": "slate",
-    "cssVariables": true,
+    "cssVariables": false,
     "prefix": ""
   },
   "aliases": {

--- a/context/archive/2026-07-24-design-system-contract/change.md
+++ b/context/archive/2026-07-24-design-system-contract/change.md
@@ -1,10 +1,10 @@
 ---
 change_id: design-system-contract
 title: Design-system and layout contract
-status: new
+status: archived
 created: 2026-07-24
 updated: 2026-07-24
-archived_at: null
+archived_at: 2026-07-24T08:47:44Z
 ---
 
 ## Notes

--- a/context/changes/design-system-contract/change.md
+++ b/context/changes/design-system-contract/change.md
@@ -1,0 +1,22 @@
+---
+change_id: design-system-contract
+title: Design-system and layout contract
+status: new
+created: 2026-07-24
+updated: 2026-07-24
+archived_at: null
+---
+
+## Notes
+
+Roadmap **F-01** (`context/foundation/roadmap.md`) — foundation slice, unblocks S-01…S-05.
+
+Settles the page skeleton + token contract so no content slice re-opens a visual decision.
+Author decisions (2026-07-24): section-level `label | content` grid collapsing below `md`;
+Ramaraja 700 + IBM Plex Mono frozen; motion limited to `transition-colors`.
+
+Retires the four recorded design risks: radius scale leaking through `rounded-md`/`rounded-lg`,
+undefined focus-ring colour, hard-coded `border-black` in `Footer.astro`, shadcn `cssVariables`
+clash with the named tokens.
+
+Implemented on branch `feat/design-system-contract` (commit `c145cac`). Merges to `development`.

--- a/context/foundation/roadmap.md
+++ b/context/foundation/roadmap.md
@@ -3,7 +3,7 @@ project: "Chrobok.dev"
 version: 1
 status: draft
 created: 2026-07-22
-updated: 2026-07-23
+updated: 2026-07-24
 prd_version: 1
 main_goal: quality
 top_blocker: time
@@ -47,7 +47,7 @@ to recruiters at any point.
 
 | ID   | Change ID                 | Outcome (user can …)                                                        | Prerequisites                  | PRD refs                       | Status   |
 | ---- | ------------------------- | --------------------------------------------------------------------------- | ------------------------------ | ------------------------------ | -------- |
-| F-01 | design-system-contract    | (foundation) page skeleton + token contract settled; no ambiguity left       | —                              | §NFRs, §Guardrails             | ready    |
+| F-01 | design-system-contract    | (foundation) page skeleton + token contract settled; no ambiguity left       | —                              | §NFRs, §Guardrails             | done     |
 | F-02 | v1-release-staging        | (foundation) v1 work merges without reaching production                      | —                              | §Success Criteria (primary)    | done     |
 | F-03 | inspection-gate           | (foundation) build, types and lint gate every v1 merge; inspection checklist runnable | F-02                  | §NFRs, §Guardrails             | proposed |
 | S-01 | hero-first-screen         | read name, role title, core stack and a positioning line, and reach email + CV, without scrolling | F-01, F-02   | US-01, FR-001, FR-002, FR-003  | proposed |
@@ -100,7 +100,7 @@ Foundations below assume these are present and do NOT re-scaffold them.
   - Does Ramaraja 700 against IBM Plex Mono read as craftsmanship or as decoration? Reverting is cheap now and expensive after five sections are built. — Owner: author. Block: no.
   - Is any motion allowed beyond `transition-colors` on hover? — Owner: author. Block: no.
 - **Risk:** Sequenced first because `main_goal: quality` and because every content slice inherits these decisions; the failure mode is settling them implicitly inside S-01 and then retro-fitting four other sections.
-- **Status:** ready
+- **Status:** done
 
 ### F-02: v1 release staging
 
@@ -269,3 +269,4 @@ Foundations below assume these are present and do NOT re-scaffold them.
 ## Done
 
 - **F-02: (foundation) v1 work merges and deploys to a preview without touching production — `main` keeps serving the placeholder until the cutover.** — Archived 2026-07-23 → `context/archive/2026-07-23-v1-release-staging/`. Lesson: —.
+- **F-01: (foundation) the page skeleton and token contract are settled — grid and its mobile collapse, the border-radius scale, the focus-visible ring, and the rule for keeping hard-coded values out — so no content slice has to re-open a visual decision.** — Archived 2026-07-24 → `context/archive/2026-07-24-design-system-contract/`. Lesson: —.

--- a/src/components/footer/Footer.astro
+++ b/src/components/footer/Footer.astro
@@ -2,7 +2,7 @@
 const year = new Date().getFullYear();
 ---
 
-<footer class="mt-2 border-t border-black pt-2 text-center">
+<footer class="mt-2 border-t border-border-default pt-2 text-center">
   <p class="text-xs">
     &copy; {year} Chrobok.dev. All rights reserved.
   </p>

--- a/src/components/layout/Section.astro
+++ b/src/components/layout/Section.astro
@@ -1,0 +1,39 @@
+---
+/*
+ * Section — the page skeleton primitive (F-01 design-system contract).
+ *
+ * Wraps content in a semantic <section> with a scroll anchor and the centered
+ * container. When a `label` slot is provided it lays the section out as the
+ * "label | content" two-column grid on md+ and collapses to a single column
+ * below md; without a `label` slot the content spans the full column.
+ *
+ * Semantics are left to the caller: pass the section heading (and its label)
+ * as slot content so each section owns its own heading level and ARIA wiring.
+ */
+interface Props {
+  /** Anchor id — also the scroll target for the sticky section nav (S-06). */
+  id: string;
+  /** Extra classes for the outer <section>. */
+  class?: string;
+}
+
+const { id, class: className } = Astro.props;
+const hasLabel = Astro.slots.has('label');
+---
+
+<section id={id} class:list={['scroll-mt-section py-section', className]}>
+  <div class="container">
+    <div class:list={['grid gap-grid', hasLabel ? 'grid-cols-1 md:grid-cols-section' : 'grid-cols-1']}>
+      {
+        hasLabel && (
+          <div>
+            <slot name="label" />
+          </div>
+        )
+      }
+      <div>
+        <slot />
+      </div>
+    </div>
+  </div>
+</section>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -14,6 +14,15 @@
     line-height: 1.7;
   }
 
+  /*
+   * Focus-visible ring contract: every keyboard-focusable element gets the same
+   * ring (focus-ring token) with a page-bg offset. Colours come from the ring
+   * token defaults in tailwind.config.mjs — never hard-coded here or at call sites.
+   */
+  :focus-visible {
+    @apply outline-none ring-2 ring-offset-2;
+  }
+
   h1,
   h2,
   h3,

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -20,6 +20,7 @@ export default {
         'text-secondary': '#333333',
         'border-default': '#000000',
         'hover-bg': '#E8E8E8',
+        'focus-ring': '#000000',
       },
       fontFamily: {
         heading: ['Ramaraja', 'serif'],
@@ -34,12 +35,31 @@ export default {
       gap: {
         grid: '3rem', // 48px
       },
-      borderRadius: {
-        DEFAULT: '0px',
+      gridTemplateColumns: {
+        // Section-level "label | content" skeleton; collapses to 1 column below md.
+        section: 'minmax(0, 12rem) minmax(0, 1fr)',
       },
+      // Focus-visible ring token: the ring colour is the design-system focus-ring
+      // token and the offset matches the page background, so `ring-2 ring-offset-2`
+      // renders correctly without ever hard-coding a colour at the call site.
+      ringColor: ({ theme }) => ({ DEFAULT: theme('colors.focus-ring') }),
+      ringOffsetColor: ({ theme }) => ({ DEFAULT: theme('colors.page-bg') }),
       minHeight: {
         'without-footer': 'calc(100dvh - 33px)',
       },
+    },
+    // Square corners are the design identity: every named radius resolves to 0 so
+    // `rounded-md` / `rounded-lg` / `rounded-full` can never leak a rounded corner.
+    borderRadius: {
+      none: '0px',
+      sm: '0px',
+      DEFAULT: '0px',
+      md: '0px',
+      lg: '0px',
+      xl: '0px',
+      '2xl': '0px',
+      '3xl': '0px',
+      full: '0px',
     },
   },
   plugins: [require('tailwindcss-animate')],


### PR DESCRIPTION
## Summary

Foundation slice **F-01** (`design-system-contract`) — settles the page skeleton and token contract so no content slice (S-01…S-05) has to re-open a visual decision. Retires the four recorded design risks:

- **Radius scale leak** — every named `borderRadius` (`sm`/`md`/`lg`/`full`…) now resolves to `0`, so `rounded-*` can never reintroduce a rounded corner.
- **Undefined focus-ring** — new `focus-ring` token drives `ringColor`/`ringOffsetColor` defaults, plus a global `:focus-visible` rule in `globals.css` (offset = `page-bg`) so every keyboard-focusable element gets the same ring.
- **Hard-coded `border-black`** in `Footer.astro` → `border-border-default`.
- **shadcn token clash** — `components.json` set to `cssVariables: false`, ending the `slate` CSS-var vs named-token conflict.

Also adds the page skeleton primitive `src/components/layout/Section.astro` (section-level `label | content` grid, collapses to one column below `md`) and records the settled contract in `.claude/rules/design-system.md` (grid + breakpoint, radius, focus, motion, no-hard-code rule).

Author decisions frozen for v1: section-level grid collapsing below `md`; Ramaraja 700 + IBM Plex Mono; motion limited to `transition-colors`.

## Test plan

- [x] `yarn lint` clean
- [x] `yarn build` (`astro check && astro build`) passes
- [ ] Keyboard-focus a link → black focus ring with page-bg offset is visible
- [ ] No visual change to the live placeholder (`index.astro` untouched)
- [ ] Merge targets `development` (never `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)