### PR TITLE
chore: wire Linear-only tracker into pr-ready/pr-merge flow

### DIFF
--- a/.claude/skills/pr-merge/SKILL.md
+++ b/.claude/skills/pr-merge/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-merge
-description: Close out a reviewed change end-to-end — archive it, squash-merge its PR to main, and bring the trackers to their terminal state. Runs /10x-archive (which closes the matching roadmap item and commits the folder move), pushes that commit into the PR, waits for all GitHub checks to pass, squash-merges with --delete-branch, then moves the Linear issue to Done and closes the GitHub-mirror issue. This is the counterpart to /pr-ready (which only opens the PR + moves trackers to "in review"). Trigger on "/pr-merge <change-id>" or natural-language close-out requests like "the PR for places-schema-foundation is approved, merge it and close everything out" / "squash and merge this and archive the change" / "land this PR".
+description: Close out a reviewed change end-to-end — archive it, squash-merge its PR into `development`, and bring the tracker to its terminal state. Runs /10x-archive (which closes the matching roadmap item and commits the folder move), pushes that commit into the PR, waits for all GitHub checks to pass, squash-merges with --delete-branch, then moves the Linear issue to Done. Linear-only — this project has no GitHub-issues mirror. This is the counterpart to /pr-ready (which only opens the PR + moves the tracker to "in review"). Trigger on "/pr-merge <change-id>" or natural-language close-out requests like "the PR for places-schema-foundation is approved, merge it and close everything out" / "squash and merge this and archive the change" / "land this PR".
 argument-hint: "<change-id>"
 allowed-tools:
   - Read
@@ -8,24 +8,24 @@ allowed-tools:
   - Bash
   - AskUserQuestion
   - Skill
-  - mcp__linear-server__get_issue
-  - mcp__linear-server__save_issue
-  - mcp__linear-server__list_issue_statuses
+  - mcp__plugin_linear_linear__get_issue
+  - mcp__plugin_linear_linear__save_issue
+  - mcp__plugin_linear_linear__list_issue_statuses
 ---
 
 # /pr-merge — Land and close out a reviewed change
 
 Take a change whose PR has been reviewed and approved and finish it: archive the change
-folder (which also closes its roadmap item), squash-merge the PR onto `main`, delete the
-branch, and move both tracker mirrors to their done/closed state. This is the
-"it's approved, ship it and close everything out" button — the back half of the lifecycle
-whose front half is `/pr-ready`.
+folder (which also closes its roadmap item), squash-merge the PR into its base
+(`development` for every v1 slice — never `main`, which is production), delete the branch,
+and move the Linear issue to Done. This is the "it's approved, ship it and close everything
+out" button — the back half of the lifecycle whose front half is `/pr-ready`.
 
 The hard part of this skill is **ordering and gates**, not the individual commands. Each
 step has a reason it comes where it does — read the "why" notes, because doing these out
 of order (e.g. merging before the archive commit is pushed, or merging on red CI) produces
-messes that are annoying to untangle: orphaned archive commits, a `main` that's missing the
-folder move, or a closed issue for a change that didn't actually merge.
+messes that are annoying to untangle: orphaned archive commits, a `development` that's missing
+the folder move, or a closed issue for a change that didn't actually merge.
 
 ## Initial Response
 
@@ -94,7 +94,7 @@ Closing out <change-id> (PR #<n>, "<pr title>"):
   1. /10x-archive <change-id>      → closes roadmap item, commits the folder move
   2. push the archive commit into PR #<n>, wait for CI to go green
   3. squash-merge PR #<n> --delete-branch
-  4. Linear <CHR-n> → Done · GitHub mirror issue #<n> → closed
+  4. Linear <CHR-n> → Done
 ```
 
 **If Step 1 set the `already_archived` flag, skip the archive entirely** — note "archive
@@ -106,7 +106,7 @@ Otherwise, **invoke the `/10x-archive` skill** with the change-id (via the Skill
 it **while checked out on the feature branch** so its `chore(archive): close <change-id>`
 commit lands on the branch — and therefore inside this PR. That's the whole reason archive
 comes before the merge: we want the folder move + roadmap close to be part of the squashed
-history on `main`, not stranded on a branch that's about to be deleted.
+history on `development`, not stranded on a branch that's about to be deleted.
 
 `/10x-archive` has its own warn-and-confirm gate (incomplete progress, missing impl-review,
 etc.) and a hard block on uncommitted changes. **Respect its outcome:**
@@ -139,8 +139,8 @@ one fails. Read the exit code:
 
 - **Exit 0** → all checks green, continue to Step 5.
 - **Non-zero** → checks failed or were cancelled. STOP and report which ones (`gh pr checks
-  <number>` for the table). Do not merge red CI — fixing on `main` after the fact is exactly
-  the round-trip this gate exists to prevent.
+  <number>` for the table). Do not merge red CI — fixing on `development` after the fact is
+  exactly the round-trip this gate exists to prevent.
 
 If the repo has **no checks configured** (`gh pr checks` says "no checks"), there's nothing
 to gate on — note that and continue.
@@ -151,8 +151,9 @@ to gate on — note that and continue.
 gh pr merge <number> --squash --delete-branch
 ```
 
-Squash keeps `main` to one commit per change. `--delete-branch` removes the merged branch
-(remote + local) — `gh` switches you to `main` as part of this. Confirm the merge landed:
+Squash keeps `development` to one commit per change. `--delete-branch` removes the merged
+branch (remote + local) — `gh` switches you to `development` (the default branch) as part of
+this. Confirm the merge landed:
 
 ```bash
 gh pr view <number> --json state,mergedAt   # state should be MERGED
@@ -161,47 +162,35 @@ gh pr view <number> --json state,mergedAt   # state should be MERGED
 If the merge fails (e.g. branch protection needs an approval `gh` can't satisfy, or a
 late-arriving conflict), STOP and report — don't retry with bypass flags.
 
-## Step 6 — Bring the trackers to their terminal state
+## Step 6 — Bring the tracker to its terminal state
 
 The roadmap item is already closed (that happened inside `/10x-archive`). What's left is the
-two issue mirrors. Use the same mapping logic `/pr-ready` uses.
+single Linear issue. Use the same mapping logic `/pr-ready` uses.
 
 ### 6.1 Resolve the issue mapping
 
-Read `context/foundation/tasks-linear.md` and `context/foundation/tasks-github.md`. Both
-carry an "Issue mapping" table keyed via the roadmap ID. Cross-reference
-`context/foundation/roadmap.md`'s **Change ID** column to get from `<change-id>` to a
-roadmap ID (`F-01` / `S-02`), then to the Linear identifier (`CHR-n`) and the GitHub issue
-number (`#n`).
+Read `context/foundation/tasks-linear.md`. Its "Issue mapping (roadmap → Linear)" table is
+keyed via the roadmap ID — cross-reference `context/foundation/roadmap.md`'s **Change ID**
+column to get from `<change-id>` to a roadmap ID (`F-01` / `S-02`), then to the Linear
+identifier (`CHR-n`). This project has no GitHub-issues mirror (see the file's "GitHub is not
+used" note), so there is nothing to close on GitHub — the merged PR is the GitHub-side record.
 
-If you can't find an unambiguous row — the change-id isn't in the roadmap, or the tables
-disagree — **stop and ask** which issues to update. Moving/closing the wrong issue is more
-confusing to untangle than a short pause now.
+If you can't find an unambiguous row — the change-id isn't in the roadmap — **stop and ask**
+which issue to update. Moving the wrong issue is more confusing to untangle than a short pause now.
 
 ### 6.2 Linear: move to "Done"
 
 ```
-mcp__linear-server__get_issue           — fetch current state (sanity-check title)
-mcp__linear-server__list_issue_statuses — confirm the team's "Done" (completed) state name
-mcp__linear-server__save_issue          — id: <CHR-n>, state: "Done"
+mcp__plugin_linear_linear__get_issue           — fetch current state (sanity-check title)
+mcp__plugin_linear_linear__list_issue_statuses — confirm the team's "Done" (completed) state name
+mcp__plugin_linear_linear__save_issue          — id: <CHR-n>, state: "Done"
 ```
 
 Only move forward. If it's already Done, leave it. If it's still in an early state
 (Backlog/Todo) rather than In Review, that's odd for something you just merged — flag it but
 still move it to Done, since the merge is ground truth.
 
-### 6.3 GitHub mirror: close the issue
-
-The GitHub mirror's `status:*` labels track *planning readiness* (`ready`/`proposed`/
-`blocked`), not implementation progress — there's no `status:done`, so closing the issue is
-the canonical "this is done" signal (see `tasks-github.md` → "Keeping doc and issues in
-sync", which says to close the issue when a change is archived). Close it with a comment that
-points at the merge:
-
-```bash
-gh issue close <issue-number> --repo <owner>/<repo> --reason completed \
-  --comment "Merged to main via #<PR-number> and archived."
-```
+That's the whole tracker close-out — no GitHub-issues mirror to touch in this project.
 
 ## Step 7 — Confirm
 
@@ -210,9 +199,8 @@ Print a short close-out summary so the user sees the whole lifecycle ended clean
 ```
 ✓ Closed out <change-id>
   archived:  context/archive/<date>-<change-id>/   (roadmap item closed by /10x-archive)
-  merged:    PR #<n> squashed onto main, branch deleted
+  merged:    PR #<n> squashed onto development, branch deleted
   Linear:    <CHR-n> → Done
-  GitHub:    issue #<n> → closed
 ```
 
 ## What this skill deliberately does NOT do
@@ -223,10 +211,12 @@ Print a short close-out summary so the user sees the whole lifecycle ended clean
   Steps 1 and 4 exist because un-gated merges are the expensive mistake here.
 - **Doesn't re-close the roadmap item.** `/10x-archive` owns the roadmap (`Status: done` +
   `## Done` entry); duplicating that here would just risk drift.
-- **Doesn't rewrite the `tasks-github.md` / `tasks-linear.md` markdown tables.** It treats
-  them as the issue-mapping source of record (same as `/pr-ready`) and brings the *live*
-  trackers they describe to their terminal state. If you want the markdown tables themselves
-  edited on merge, that's a deliberate convention change to ask for, not a side effect.
+- **Doesn't rewrite the `tasks-linear.md` markdown table.** It treats it as the issue-mapping
+  source of record (same as `/pr-ready`) and brings the *live* Linear issue it describes to its
+  terminal state. If you want the markdown table itself edited on merge, that's a deliberate
+  convention change to ask for, not a side effect.
+- **Doesn't target `main`.** v1 slice PRs merge into `development`; `main` is production and the
+  single `development` → `main` release PR (roadmap S-08) is a separate, deliberate event.
 - **Doesn't use merge-bypass flags** (`--admin`, `--no-verify`, signing bypass). If branch
   protection blocks the merge, that's a signal to surface, not to override.
 ```

--- a/.claude/skills/pr-ready/SKILL.md
+++ b/.claude/skills/pr-ready/SKILL.md
@@ -1,24 +1,25 @@
 ---
 name: pr-ready
-description: Open the PR for a finished change and sync its Linear and GitHub-mirror tracker issues to "in review" — push the branch, create the PR with a generated summary/test plan, move the Linear issue to In Review with a link to the PR, and comment the PR link on the GitHub mirror issue. Trigger on "/pr-ready <change-id>" or natural-language completion announcements like "I finished implementing places-schema-foundation, prepare the PR" / "open a PR for this and sync the trackers".
+description: Open the PR for a finished change and sync its Linear tracker issue to "in review" — push the branch, create the PR against `development` with a generated summary/test plan, and move the Linear issue to In Review with a link to the PR. Trigger on "/pr-ready <change-id>" or natural-language completion announcements like "I finished implementing places-schema-foundation, prepare the PR" / "open a PR for this and sync the trackers".
 argument-hint: "<change-id>"
 allowed-tools:
   - Read
   - Bash
   - AskUserQuestion
-  - mcp__linear-server__get_issue
-  - mcp__linear-server__save_issue
-  - mcp__linear-server__list_issue_statuses
+  - mcp__plugin_linear_linear__get_issue
+  - mcp__plugin_linear_linear__save_issue
+  - mcp__plugin_linear_linear__list_issue_statuses
 ---
 
 # /pr-ready — Ship a finished change
 
 Take a change that's done being implemented and put it in front of reviewers: push the
-branch, open the GitHub PR, and move its two tracker mirrors (Linear + the GitHub-issues
-mirror) into "in review" so the backlog reflects reality. This is the
-"I'm done coding, get it ready for review" button — it does not merge anything or touch
-`roadmap.md` (that only changes at planning time or archive time, see "What this skill
-deliberately does NOT do").
+branch, open the GitHub PR **against `development`** (never `main` — `main` is the Vercel
+production branch), and move its Linear tracker issue into "in review" so the backlog
+reflects reality. This project tracks only in Linear — there is no GitHub-issues mirror
+(see `context/foundation/tasks-linear.md`). This is the "I'm done coding, get it ready for
+review" button — it does not merge anything or touch `roadmap.md` (that only changes at
+planning time or archive time, see "What this skill deliberately does NOT do").
 
 ## Initial Response
 
@@ -57,7 +58,7 @@ PR"), extract the change-id from that description — match it against `ls conte
    ship:
    ```bash
    git status -sb
-   git log main..HEAD --oneline   # commits this PR will carry
+   git log development..HEAD --oneline   # commits this PR will carry (base is development)
    ```
    If there are uncommitted changes, look at whether they plausibly belong to this change
    (touch the same files / folders) or look unrelated (e.g. editing CLAUDE.md, unrelated
@@ -90,7 +91,7 @@ list`/`gh repo view` can't resolve the repo, `gh auth switch --user <owner-of-th
 
 1. Push with upstream tracking: `git push -u origin <branch>`.
 2. Build the PR body from what's actually in the branch, not boilerplate:
-   - **Summary**: 2-4 bullets derived from `git log main..HEAD --reverse --format="- %s"`,
+   - **Summary**: 2-4 bullets derived from `git log development..HEAD --reverse --format="- %s"`,
      grouped/rephrased into user-meaningful bullets (not a raw commit dump).
    - **Test plan**: pull verification steps from the change folder if it has them
      (`context/changes/<change-id>/plan.md` or similar — look for an existing test/manual
@@ -99,7 +100,7 @@ list`/`gh repo view` can't resolve the repo, `gh auth switch --user <owner-of-th
      anything the change's "Risk" notes flagged.
 3. Create it:
    ```bash
-   gh pr create --base main --head <branch> --title "<type>: <concise title>" --body "$(cat <<'EOF'
+   gh pr create --base development --head <branch> --title "<type>: <concise title>" --body "$(cat <<'EOF'
    ## Summary
    - ...
 
@@ -113,16 +114,15 @@ list`/`gh repo view` can't resolve the repo, `gh auth switch --user <owner-of-th
 ## Step 5 — Show the plan before touching the trackers
 
 You've now done the (effectively one-shot, hard-to-undo-cleanly) GitHub actions. Before
-making the Linear/GitHub-mirror edits — which are easy to get wrong if the issue mapping
-is stale — show the user one short summary of what you're about to do and proceed without
+making the Linear edit — which is easy to get wrong if the issue mapping is stale — show
+the user one short summary of what you're about to do and proceed without
 waiting for a reply, e.g.:
 
 ```
 PR #19 is open: https://github.com/<owner>/<repo>/pull/19
 
-Now syncing trackers:
+Now syncing the tracker:
   - Linear CHR-5 → move Todo → In Review, attach PR #19 link
-  - GitHub mirror issue #1 → comment with the PR #19 link
 ```
 
 This is a heads-up, not a gate — if the resolved issue numbers look wrong to the user
@@ -133,11 +133,11 @@ this change, that's when to actually stop and ask — see Step 6.1.)
 
 ### 6.1 Resolve the issue mapping
 
-Read `context/foundation/tasks-linear.md` and `context/foundation/tasks-github.md`. Both
-carry an "Issue mapping (roadmap → …)" table keyed by **Change ID** (via the roadmap ID —
-cross-reference `context/foundation/roadmap.md`'s `Change ID` column to get from
-`<change-id>` to a roadmap ID like `F-01`/`S-02`, then to the table row). That row gives
-you the Linear identifier (`CHR-N`) and the GitHub issue number (`#N`).
+Read `context/foundation/tasks-linear.md`. Its "Issue mapping (roadmap → Linear)" table is
+keyed by the roadmap ID — cross-reference `context/foundation/roadmap.md`'s `Change ID`
+column to get from `<change-id>` to a roadmap ID like `F-01`/`S-02`, then to the table row,
+which gives you the Linear identifier (`CHR-N`). This project has no GitHub-issues mirror
+(see the file's "GitHub is not used" note) — the PR itself is the only GitHub-side record.
 
 If you can't find an unambiguous row — the change-id isn't in the roadmap, or the tables
 disagree — **stop and ask** which issues to update rather than guessing from branch names
@@ -147,29 +147,18 @@ more confusing to untangle later than a short pause now.
 ### 6.2 Linear: move to "In Review" + attach the PR link
 
 ```
-mcp__linear-server__get_issue        — fetch current state (sanity-check title/status)
-mcp__linear-server__list_issue_statuses  — confirm "In Review" exists for this team
-mcp__linear-server__save_issue       — id: <CHR-N>, state: "In Review",
-                                        links: [{url: <PR URL>, title: "PR #<N>: <PR title>"}]
+mcp__plugin_linear_linear__get_issue           — fetch current state (sanity-check title/status)
+mcp__plugin_linear_linear__list_issue_statuses — confirm "In Review" exists for this team
+mcp__plugin_linear_linear__save_issue          — id: <CHR-N>, state: "In Review",
+                                                 links: [{url: <PR URL>, title: "PR #<N>: <PR title>"}]
 ```
 
 Only move it forward (Todo/Backlog → In Review). If the issue is already further along
 (In Review, Done) leave its state alone — just add the link if missing — rather than
 moving it backward.
 
-### 6.3 GitHub mirror: comment with the PR link
-
-```bash
-gh issue comment <issue-number> --repo <owner>/<repo> --body "Implementation complete and in review: #<PR-number>"
-```
-
-Don't touch the issue's `status:*` label. Read `tasks-github.md`'s "Mapping decisions" /
-label table first if you're unsure why — but the short version is that those labels mirror
-`roadmap.md`'s **planning-readiness** status (`ready`/`proposed`/`blocked`), a different axis
-than implementation/PR progress. There is no `status:in-review` in the taxonomy, and adding
-one would be inventing a convention the user hasn't asked for. The GitHub-native way to
-track "this issue has a PR in flight" is the cross-reference comment/link, which is what
-you just added — same as Linear's `links` attachment, just GitHub's native mechanism for it.
+That's the whole tracker sync — there is no GitHub-issues mirror in this project, so nothing
+else to touch. The PR opened in Step 4 is the GitHub-side record.
 
 ## What this skill deliberately does NOT do
 
@@ -179,8 +168,8 @@ you just added — same as Linear's `links` attachment, just GitHub's native mec
   is implementation-progress granularity that the roadmap deliberately doesn't track —
   that lives in the change folder's `change.md` (`status: impl_reviewed` etc.) and in
   Linear's workflow state. Resist the urge to "complete the picture" by editing it anyway.
-- **Doesn't merge the PR or close the issues.** "Ready for review" is the end state this
+- **Doesn't merge the PR or close the issue.** "Ready for review" is the end state this
   skill produces — closing/merging is a human (or separate, explicit) action.
-- **Doesn't invent a `status:in-review` GitHub label.** See 6.3 — adding new conventions
-  to a documented taxonomy is a decision for the user to make deliberately, not a side
-  effect of getting a PR ready.
+- **Doesn't target `main`.** `main` is the Vercel production branch; every v1 PR opens
+  against `development`. The single `development` → `main` release PR is a deliberate,
+  separate event (roadmap S-08), never something this skill opens.

--- a/context/foundation/tasks-linear.md
+++ b/context/foundation/tasks-linear.md
@@ -1,0 +1,80 @@
+---
+project: "Chrobok.dev"
+task_system: linear
+workspace: chrobok-dev
+team: Chrobok-dev (CHR)
+linear_project: chrobok-dev-website
+created: 2026-07-23
+source_of_record: context/foundation/roadmap.md
+mirrors: none (Linear-only — no GitHub-issues mirror in this project)
+---
+
+# Task Management: Linear
+
+This project's backlog is mirrored into **Linear** (workspace `chrobok-dev`, team **Chrobok-dev** /
+key `CHR`, project **chrobok-dev-website**). `roadmap.md` remains the human source-of-record; the
+Linear issues are its single live mirror. This file documents the Linear-side conventions so future
+migrations/edits — and the `/pr-ready` and `/pr-merge` skills — stay consistent.
+
+Unlike the sibling `10x-Travel` project, this mirror is intentionally lean: no GitHub mirror, no custom
+labels, no project milestones. Status is carried entirely by the Linear workflow state.
+
+## Tooling
+
+- **Linear MCP server** (`mcp__plugin_linear_linear__*`): `save_issue`, plus `list_issues` /
+  `list_issue_statuses` / `get_issue` for verification.
+- The team and the `chrobok-dev-website` project already existed in the workspace; the 11 issues were
+  created from `roadmap.md` (one per roadmap item), with empty label sets.
+
+## Issue mapping (roadmap → Linear)
+
+Keyed by roadmap ID. The **Change ID** column lets the skills resolve a `<change-id>` (branch /
+`context/changes/` slug) straight to the Linear identifier without a second lookup. The **State** column
+is a point-in-time snapshot — Linear is the live source of truth for workflow state.
+
+| Linear | Roadmap ID | Change ID                 | Title (short)                    | State snapshot |
+| ------ | ---------- | ------------------------- | -------------------------------- | -------------- |
+| CHR-28 | F-01       | design-system-contract    | Design-system & layout contract  | In Review      |
+| CHR-29 | F-02       | v1-release-staging        | v1 release staging               | Done           |
+| CHR-30 | F-03       | inspection-gate           | Inspection gate                  | Backlog        |
+| CHR-31 | S-01       | hero-first-screen         | Hero — first screen              | Backlog        |
+| CHR-32 | S-02       | work-proof-block          | Work — proof block               | Backlog        |
+| CHR-33 | S-03       | skills-two-tier           | Skills — two tiers               | Backlog        |
+| CHR-34 | S-04       | about-and-journal         | About & journal                  | Backlog        |
+| CHR-35 | S-05       | footer-contact            | Footer contact                   | Backlog        |
+| CHR-36 | S-06       | sticky-section-nav        | Sticky section nav               | Backlog        |
+| CHR-37 | S-07       | inspection-hardening-pass | Inspection hardening pass        | Backlog        |
+| CHR-38 | S-08       | v1-production-cutover     | v1 production cutover (★ north)  | Backlog        |
+
+## Conventions
+
+- **One issue per roadmap item.** Title and body mirror the roadmap; body carries Outcome, Change ID,
+  PRD refs, Prerequisites, Unknowns and Risk verbatim.
+- **Status lives in the workflow state**, not in a label. Team states: `Backlog`, `Todo`,
+  `In Progress`, `In Review`, `Done`, `Canceled`, `Duplicate`. A slice that becomes ready moves
+  Backlog → Todo → In Progress → In Review → Done.
+- **No custom labels or milestones.** They exist in the `10x-Travel` mirror but were deliberately not
+  recreated here — this v1 is a single linear sequence, so the workflow state alone is enough.
+
+## Status flow driven by the skills
+
+The Linear workflow state is the implementation-progress axis, distinct from the roadmap's
+planning-readiness `Status` (which only `/10x-plan` and `/10x-archive` touch).
+
+- **`/pr-ready`** moves the issue **Todo/Backlog → In Review** and attaches the PR link. Forward-only —
+  an issue already In Review/Done keeps its state; the link is still attached if missing.
+- **`/pr-merge`** moves the issue **→ Done** after the squash-merge lands.
+
+## GitHub is not used
+
+This project has **no** GitHub-issues mirror and no `tasks-github.md`. Issues live only in Linear.
+`/pr-ready` and `/pr-merge` skip every GitHub-mirror step here — the PR itself (opened against
+`development`) plus the Linear state change are the whole tracker surface. Do not create a
+`tasks-github.md` or comment on GitHub issues for this repo.
+
+## Keeping doc and issues in sync
+
+`roadmap.md` stays the source-of-record. When a roadmap item changes status (a slice becomes `ready`,
+or is archived via `/10x-archive`), move the Linear workflow state **and** edit `roadmap.md`; keep them
+from drifting. If a new roadmap item is mirrored into Linear, append its row to the table above — the
+skills treat this table as the mapping source of record and do not edit it themselves.


### PR DESCRIPTION
## Summary

Two flow fixes surfaced while shipping F-01, so the `/pr-ready` → `/pr-merge` lifecycle matches how this project is actually set up:

- **New `context/foundation/tasks-linear.md`** — the roadmap → Linear (`CHR-28`…`CHR-38`) issue-mapping table the skills read to resolve which issue to move. Modeled on the sibling `10x-travel` convention but lean: Linear-only, no labels/milestones, with an explicit "GitHub is not used" section.
- **`pr-ready` / `pr-merge` skills aligned with the release model:**
  - PRs open against **`development`**, never `main` (`main` is the Vercel production branch). Summary is built from `development..HEAD`.
  - **Linear-only**: the GitHub-issues-mirror steps are removed (this project has no such mirror), so the skills no longer try to comment on / close issues that don't exist.
  - Linear MCP tool names corrected from the stale `mcp__linear-server__*` to the live `mcp__plugin_linear_linear__*`.

Both `--base main` defaults in the skill templates were the concrete bug: left unfixed, the next `/pr-ready` would have opened a PR straight against production.

## Test plan

- [x] `tasks-linear.md` mapping cross-checked against live Linear (CHR-28…CHR-38, team CHR / project chrobok-dev-website)
- [x] No leftover `mcp__linear-server__`, `tasks-github`, `--base main`, or GitHub-mirror references in either skill
- [ ] Next `/pr-ready` run opens against `development` and moves the mapped CHR issue to In Review
- [ ] Tooling/docs only — no app code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)