### PR TITLE
ci: inspection gate — lint CI gate + NFR runbook (F-03)

### DIFF
--- a/.github/workflows/inspect.yml
+++ b/.github/workflows/inspect.yml
@@ -1,0 +1,17 @@
+name: inspect
+
+on:
+  pull_request:
+    branches: [development]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'yarn'
+      - run: yarn install --frozen-lockfile
+      - run: yarn lint

--- a/.github/workflows/inspect.yml
+++ b/.github/workflows/inspect.yml
@@ -4,12 +4,15 @@ on:
   pull_request:
     branches: [development]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: '22'
           cache: 'yarn'

--- a/context/changes/inspection-gate/change.md
+++ b/context/changes/inspection-gate/change.md
@@ -1,0 +1,12 @@
+---
+change_id: inspection-gate
+title: Gate v1 merges on build, type-check and lint, with a repeatable NFR inspection run
+status: planned
+created: 2026-07-24
+updated: 2026-07-24
+archived_at: null
+---
+
+## Notes
+
+F-03: build, type-check and lint gate on every v1 merge into development, plus the NFR inspection checklist as a repeatable run. Create .github/ workflow from scratch and wire it as a required status check on development.

--- a/context/changes/inspection-gate/change.md
+++ b/context/changes/inspection-gate/change.md
@@ -1,7 +1,7 @@
 ---
 change_id: inspection-gate
 title: Gate v1 merges on build, type-check and lint, with a repeatable NFR inspection run
-status: planned
+status: implementing
 created: 2026-07-24
 updated: 2026-07-24
 archived_at: null

--- a/context/changes/inspection-gate/plan-brief.md
+++ b/context/changes/inspection-gate/plan-brief.md
@@ -1,0 +1,79 @@
+# F-03 Inspection Gate — Plan Brief
+
+> Full plan: `context/changes/inspection-gate/plan.md`
+> Research: `context/changes/inspection-gate/research.md`
+
+## What & Why
+
+Roadmap F-03: gate every merge into `development` on build, type-check **and lint**, and make the
+NFR inspection checklist a repeatable run rather than a memory exercise. It converts the
+"site survives a technical inspection" guardrail from a promise into a check that fails loudly.
+
+## Starting Point
+
+`development` has zero branch protection; `main` is already protected. Build + type-check already
+run on every PR via Vercel (`yarn build` = `astro check && astro build`, posted as the `Vercel`
+commit status). Lint has no server-side gate — only a bypassable husky hook. No `.github/`, no CI,
+no test runner exist yet.
+
+## Desired End State
+
+Every PR into `development` carries two required checks — `lint` (a new tiny Actions workflow) and
+`Vercel` (build + types) — and can't be squash-merged until both pass. A `docs/nfr-inspection.md`
+runbook exists that the author runs once before the `development → main` cutover, covering all four
+NFRs (perf/no-CLS, a11y, no-JS, cross-engine) plus the guardrail.
+
+## Key Decisions Made
+
+| Decision                     | Choice                                  | Why (1 sentence)                                                              | Source   |
+| ---------------------------- | --------------------------------------- | ---------------------------------------------------------------------------- | -------- |
+| Build/type gate mechanism    | Vercel deploy status (`Vercel`)         | Vercel already runs `astro check && astro build`; no new CI needed.          | Research |
+| Lint gate mechanism          | Tiny lint-only Actions workflow         | Vercel doesn't run eslint; husky is bypassable — a ~15-line job closes it.    | Research |
+| `astro check` in workflow    | No — leave types to Vercel              | Duplicating doubles job time for zero coverage gain.                          | Research |
+| Node version                 | Node 22                                 | Valid for Astro 5, future-proofs the Astro 6 (22.12+) bump.                   | Research |
+| NFR checklist                | Manual Markdown runbook + serve script  | `top_blocker: time`; CI'd NFRs aren't worth it for a solo static page.       | Plan     |
+| Required checks              | `lint` + `Vercel`                       | Full build+types+lint coverage exactly as the F-03 outcome requires.         | Plan     |
+| PR-review requirement        | None — status checks only               | Keeps a direct-push escape hatch; normal path is still a gated PR.            | Plan     |
+| `strict` / `enforce_admins`  | Both OFF                                | Avoids forced rebuilds under squash-only; parity with `main`.                | Plan     |
+
+## Scope
+
+**In scope:** lint-only CI workflow; `development` branch protection (`lint` + `Vercel`); NFR
+runbook + serve script.
+
+**Out of scope:** automating NFRs in CI (Lighthouse/axe/Playwright/no-JS); `vercel.json`;
+`push:`/scheduled triggers; repo-wide `prettier --check`; any change to `main` protection; a
+PR-review requirement on `development`.
+
+## Architecture / Approach
+
+Two phases across a merge boundary. **Phase 1** authors three files (`.github/workflows/inspect.yml`,
+`docs/nfr-inspection.md`, `scripts/nfr-serve.sh`) and lands them in `development` via a PR — on that
+PR `lint` runs for the first time, unblocked. **Phase 2** applies branch protection requiring
+`lint` + `Vercel` via `gh api`, but only after the Phase 1 PR is squash-merged. The order is
+mandatory: requiring `lint` before it has ever reported would deadlock every PR.
+
+## Phases at a Glance
+
+| Phase                          | What it delivers                                        | Key risk                                              |
+| ------------------------------ | ------------------------------------------------------- | ----------------------------------------------------- |
+| 1. Author gate artifacts       | Workflow + NFR runbook + serve script, merged via PR    | First PR must be green (`yarn lint` verified clean)   |
+| 2. Apply branch protection     | `development` requires `lint` + `Vercel`                | Must run AFTER merge, else required-check deadlock     |
+
+**Prerequisites:** F-02 done (it deliberately left `development` unprotected as the attachment
+point). Admin `gh` access via the `Pokerek` account (verified). `yarn lint` passes clean today.
+**Estimated effort:** ~1 session, 2 phases.
+
+## Open Risks & Assumptions
+
+- Direct pushes to `development` bypass lint (workflow is PR-only); this is an intentional
+  admin escape hatch given no PR-review requirement.
+- Vercel previews sit behind Deployment Protection (SSO) — the runbook targets a LOCAL build for the
+  no-JS / cross-engine checks, not the anonymous preview URL.
+- Uses the `Pokerek` account (repo owner), NOT the global-default `Karol-Chrobok`, which 404s here.
+
+## Success Criteria (Summary)
+
+- A PR into `development` cannot squash-merge until `lint` and `Vercel` are both green.
+- `docs/nfr-inspection.md` is a concrete, runnable checklist the author executes before the v1 cutover.
+- Nothing about `main` or the existing Vercel deploy flow changed.

--- a/context/changes/inspection-gate/plan.md
+++ b/context/changes/inspection-gate/plan.md
@@ -1,0 +1,279 @@
+# F-03 Inspection Gate — Implementation Plan
+
+## Overview
+
+Gate every merge into `development` on build, type-check **and lint** via required status checks,
+and turn the four NFRs behind the "survives a technical inspection" guardrail into a repeatable
+run. Build + type-check are already gated by Vercel (`yarn build` = `astro check && astro build`);
+the only server-side gap is `eslint`, closed by a tiny lint-only GitHub Actions workflow. The NFR
+checklist ships as a checked-in Markdown runbook plus one serve script — manual, not CI.
+
+## Current State Analysis
+
+- `development` has **zero** branch protection (protection endpoint returns 404). `main` is
+  protected (PR required, `required_linear_history: true`, 0 approvals, force-push/deletion blocked,
+  `enforce_admins: false`). Repo is `Pokerek/website-astro`; active `gh` account `Pokerek` has ADMIN.
+- No `.github/` directory, no workflows, no `vercel.json`, no rulesets, no test runner. Vercel is
+  wired purely via the dashboard Git integration.
+- Vercel posts a commit status named **`Vercel`** on every PR into `development` (reflects the
+  build/deploy = build + `astro check`). A separate `Vercel Preview Comments` check-run only posts
+  comments and is not a gate.
+- Local gates (`.husky/pre-commit`: `validate-branch-name` → `tsc --noEmit` → `lint-staged`;
+  `.husky/commit-msg`: commitlint) are `--no-verify`-bypassable — not server-side enforcement.
+- `yarn lint` (`eslint .`) passes clean on the current tree (verified) — the first gate PR will be green.
+
+### Key Discoveries:
+
+- The exact required-check string for the Vercel gate is `Vercel` (`research.md` §2).
+- Astro 5 needs Node 18.20.8/20.3/22+; Astro 6 will require 22.12+ — pin **Node 22** to future-proof
+  (`research.md` §3).
+- **Deadlock trap**: a required check whose workflow has never reported blocks every PR forever
+  (`.claude/rules/release-process.md:53-55`). Hence the merge-then-require ordering.
+- **Prettier markdown debt** from F-02: ~20 `.md` files fail `prettier --check` (printWidth 120).
+  The lint-only (`eslint .`) gate sidesteps this — do NOT add a repo-wide `prettier --check`
+  (`context/archive/2026-07-23-v1-release-staging/change.md:77-102`).
+- Vercel previews sit behind Deployment Protection (SSO) — a CI job cannot anonymously fetch a
+  preview URL, so the NFR runbook targets a LOCAL build for the no-JS / engine checks.
+
+## Desired End State
+
+Every PR into `development` shows two required checks — `lint` (Actions) and `Vercel` (build +
+types) — and cannot be squash-merged until both pass. A `docs/nfr-inspection.md` runbook exists that
+the author runs once before the `development → main` cutover (S-08), covering all four NFRs + the
+guardrail. Verify: `gh api repos/Pokerek/website-astro/branches/development/protection` returns
+`required_status_checks.contexts` containing `lint` and `Vercel`; a test PR into `development` is
+merge-blocked until both are green.
+
+## What We're NOT Doing
+
+- **No `astro check` in the Actions workflow** — Vercel already runs it; duplicating doubles the job
+  for zero coverage gain. Types = Vercel, lint = Actions.
+- **No automated NFR checks in CI** — no Lighthouse CI, axe-core, Playwright, pa11y, linkinator, or
+  no-JS assertions. `top_blocker: time`; the runbook is the right altitude for a solo portfolio.
+- **No `vercel.json`** — forbidden by release-process.md; Vercel infers everything.
+- **No `push:` / scheduled workflow triggers** — the gate is the PR into `development`.
+- **No repo-wide `prettier --check`** in the gate (pre-existing markdown debt would fail it).
+- **No PR-review requirement on `development`** — only status checks (user decision). Direct pushes
+  stay possible for the admin as an escape hatch.
+- **No change to `main` protection** — out of scope; `main` is already protected.
+
+## Implementation Approach
+
+Two phases separated by a merge boundary. Phase 1 authors the three artifacts on a feature branch
+and lands them in `development` via a normal PR — on that PR the `lint` check runs for the first
+time (unblocked, because it is not yet required). Only after that PR is squash-merged does Phase 2
+apply branch protection requiring `lint` + `Vercel`. This ordering is mandatory: declaring `lint`
+required before it has ever reported would deadlock every PR.
+
+## Critical Implementation Details
+
+- **Ordering / lifecycle** — Phase 2 (branch protection) must run only AFTER the Phase 1 PR is
+  squash-merged into `development`. The `lint` check name only becomes a valid, selectable required
+  context once GitHub has observed it report at least once (on the Phase 1 PR).
+- **Direct-push escape hatch** — the workflow triggers on `pull_request` only, so a direct push to
+  `development` runs no lint and is un-gated. With `enforce_admins: false` the admin can push
+  directly in a pinch; the normal, gated path is a PR. This is intentional per the user decision to
+  not require PRs on `development`.
+
+## Phase 1: Author the inspection-gate artifacts
+
+### Overview
+
+Create the lint-only CI workflow, the NFR runbook, and the serve script on a feature branch; open a
+PR into `development` for final review; confirm `lint` runs green on the PR.
+
+### Changes Required:
+
+#### 1. Lint-only CI workflow
+
+**File**: `.github/workflows/inspect.yml` (new; creates `.github/` from scratch)
+
+**Intent**: Close the one server-side gap Vercel leaves — run `eslint` on every PR into
+`development` so lint failures block the merge. Lint only; types/build stay with Vercel.
+
+**Contract**: GitHub Actions workflow, single job whose id is `lint` (this id becomes the required
+status-check name). Trigger `pull_request` with `branches: [development]`. Steps: checkout →
+`actions/setup-node@v6` with `node-version: '22'` and `cache: 'yarn'` → `yarn install
+--frozen-lockfile` → `yarn lint`. No `--fix` (a gate must not mutate), no `astro check`, no `push:`
+trigger.
+
+```yaml
+name: inspect
+
+on:
+  pull_request:
+    branches: [development]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'yarn'
+      - run: yarn install --frozen-lockfile
+      - run: yarn lint
+```
+
+#### 2. NFR inspection runbook
+
+**File**: `docs/nfr-inspection.md` (new; creates `docs/`)
+
+**Intent**: Make the four NFRs + guardrail a repeatable checklist run once before the
+`development → main` cutover (S-08), not a memory exercise. Manual, browser/DevTools + a couple of
+CLI sanity checks.
+
+**Contract**: Markdown runbook with a checkbox section per NFR mapping to concrete cheap checks:
+- **Prep**: `development` preview green; `yarn build && yarn preview` (or `scripts/nfr-serve.sh`) clean.
+- **NFR-1 Perf (<1s, no CLS)**: Chrome DevTools Lighthouse (mobile + desktop) on the preview — high
+  Performance, **CLS = 0**, LCP < 1s; Performance panel shows no layout-shift bars; usable < 1s on
+  throttled 4G.
+- **NFR-2 A11y**: full keyboard Tab-through (reachable, visible focus, logical order, no trap); axe
+  DevTools 0 critical/serious; VoiceOver spot check; contrast ≥ 4.5:1 (3:1 large text).
+- **NFR-3 No-JS**: local build + disable JS + reload → full content, nav works, no blank islands;
+  CLI sanity `curl -s localhost:4321 | grep -c "<main"` > 0.
+- **NFR-4 Cross-engine (4×2)**: state explicitly there are **3 shipping engines** — Blink
+  (Chrome + Edge), WebKit (Safari + iOS Safari), Gecko (Firefox + Firefox ESR) — so "4×2" is
+  satisfied by current+previous of each; check layout/fonts/islands/console per engine.
+- **Guardrail**: view-source semantic HTML, no TODO/placeholder/lorem, console clean, no 404 links,
+  meta/OG/favicon present.
+
+#### 3. NFR serve helper
+
+**File**: `scripts/nfr-serve.sh` (new, executable `chmod +x`)
+
+**Intent**: One-command local production build + static serve for the no-JS and cross-engine checks
+that need the built `dist/`, not the dev server.
+
+**Contract**: Bash script, `set -e`, runs `yarn build` then `yarn preview` (serves `./dist` on
+`localhost:4321`). Referenced from the runbook's Prep + NFR-3 steps.
+
+### Success Criteria:
+
+#### Automated Verification:
+
+- `yarn lint` passes locally: `yarn lint`
+- Workflow YAML is well-formed (parses): `yq . .github/workflows/inspect.yml` or equivalent
+- Serve script is executable and syntactically valid: `test -x scripts/nfr-serve.sh && bash -n scripts/nfr-serve.sh`
+- The `lint` check runs and passes on the Phase 1 PR into `development` (visible via `gh pr checks <n>`)
+
+#### Manual Verification:
+
+- Runbook reads as genuinely runnable — each NFR maps to a concrete check the author can perform
+- PR into `development` opened and reviewed as the final implementation (per user: PR = review vehicle)
+- `Vercel` check is green on the same PR (build + `astro check` pass)
+
+**Implementation Note**: After Phase 1's automated verification passes and the PR is squash-merged
+into `development`, pause for confirmation before Phase 2 — branch protection can only reference
+`lint` once it has reported on the merged PR.
+
+---
+
+## Phase 2: Apply `development` branch protection
+
+### Overview
+
+After the Phase 1 PR is squash-merged, require `lint` + `Vercel` on `development` so future merges
+are gated. Config only — applied via `gh api`, not committed.
+
+### Changes Required:
+
+#### 1. Branch protection rule on `development`
+
+**File**: none (GitHub config via `gh api`, account `Pokerek`)
+
+**Intent**: Enforce the gate — every future PR into `development` must pass `lint` and `Vercel`
+before it can be squash-merged.
+
+**Contract**: `PUT repos/Pokerek/website-astro/branches/development/protection` with:
+`required_status_checks: { strict: false, contexts: ["lint", "Vercel"] }`,
+`enforce_admins: false`, `required_pull_request_reviews: null`, `restrictions: null`. No PR-review
+requirement, `strict` off (avoids forced rebuilds under squash-only), admins not enforced (parity
+with `main`, keeps a direct-push escape hatch).
+
+### Success Criteria:
+
+#### Automated Verification:
+
+- Protection is set: `gh api repos/Pokerek/website-astro/branches/development/protection --jq '.required_status_checks.contexts'` returns `["lint","Vercel"]` (order-independent)
+- `strict` is false: `... --jq '.required_status_checks.strict'` → `false`
+- Admins not enforced: `... --jq '.enforce_admins.enabled'` → `false`
+- No PR-review requirement present: `... --jq '.required_pull_request_reviews'` → `null` / absent
+
+#### Manual Verification:
+
+- A subsequent PR into `development` shows both `lint` and `Vercel` as required and is
+  merge-blocked until both pass
+- Squash-and-merge remains the only merge button (unchanged repo-level setting)
+
+**Implementation Note**: This phase runs against live GitHub config. Confirm the active `gh` account
+is `Pokerek` (`gh auth status`) before the `PUT` — `Karol-Chrobok/website-astro` does not exist.
+
+---
+
+## Testing Strategy
+
+### Automated:
+
+- `yarn lint` green locally and on the PR (the gate's own subject).
+- Workflow + script static validation (YAML parse, `bash -n`, executable bit).
+- Post-Phase-2 API assertions on the protection payload.
+
+### Manual Testing Steps:
+
+1. Open the Phase 1 PR into `development`; confirm `lint` and `Vercel` both report and pass.
+2. Squash-merge; confirm `.github/workflows/inspect.yml`, `docs/nfr-inspection.md`,
+   `scripts/nfr-serve.sh` are on `development`.
+3. Apply Phase 2 protection; open a trivial throwaway PR into `development` and confirm the merge
+   button is blocked until checks pass (then close it).
+4. Walk the NFR runbook end-to-end once against the `development` preview to confirm it's runnable.
+
+## Migration Notes
+
+None — additive. No existing config is changed; `main` protection is untouched. Rollback is deleting
+the workflow file and removing the `development` protection rule (`gh api -X DELETE
+.../branches/development/protection`).
+
+## References
+
+- Research: `context/changes/inspection-gate/research.md`
+- Roadmap F-03: `context/foundation/roadmap.md:118-130`
+- Constraints: `.claude/rules/release-process.md:43-64`
+- NFRs / guardrail: `context/foundation/prd.md:96-106, 220-233`
+- F-02 groundwork: `context/archive/2026-07-23-v1-release-staging/{plan.md:67-68,288-289, change.md:36-41,77-102}`
+- Tracker: `context/foundation/tasks-linear.md:39` (CHR-30)
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles. See `references/progress-format.md`.
+
+### Phase 1: Author the inspection-gate artifacts
+
+#### Automated
+
+- [ ] 1.1 `yarn lint` passes locally
+- [ ] 1.2 Workflow YAML is well-formed (parses)
+- [ ] 1.3 Serve script is executable and syntactically valid (`test -x` + `bash -n`)
+- [ ] 1.4 `lint` check runs and passes on the Phase 1 PR into `development`
+
+#### Manual
+
+- [ ] 1.5 Runbook reads as genuinely runnable — each NFR maps to a concrete check
+- [ ] 1.6 PR into `development` opened and reviewed as the final implementation
+- [ ] 1.7 `Vercel` check green on the same PR
+
+### Phase 2: Apply `development` branch protection
+
+#### Automated
+
+- [ ] 2.1 Protection contexts return `["lint","Vercel"]`
+- [ ] 2.2 `required_status_checks.strict` is `false`
+- [ ] 2.3 `enforce_admins.enabled` is `false`
+- [ ] 2.4 `required_pull_request_reviews` is null/absent
+
+#### Manual
+
+- [ ] 2.5 A subsequent PR into `development` shows both checks required and is merge-blocked until green
+- [ ] 2.6 Squash-and-merge remains the only merge button

--- a/context/changes/inspection-gate/plan.md
+++ b/context/changes/inspection-gate/plan.md
@@ -253,9 +253,9 @@ the workflow file and removing the `development` protection rule (`gh api -X DEL
 
 #### Automated
 
-- [ ] 1.1 `yarn lint` passes locally
-- [ ] 1.2 Workflow YAML is well-formed (parses)
-- [ ] 1.3 Serve script is executable and syntactically valid (`test -x` + `bash -n`)
+- [x] 1.1 `yarn lint` passes locally
+- [x] 1.2 Workflow YAML is well-formed (parses)
+- [x] 1.3 Serve script is executable and syntactically valid (`test -x` + `bash -n`)
 - [ ] 1.4 `lint` check runs and passes on the Phase 1 PR into `development`
 
 #### Manual

--- a/context/changes/inspection-gate/plan.md
+++ b/context/changes/inspection-gate/plan.md
@@ -256,13 +256,13 @@ the workflow file and removing the `development` protection rule (`gh api -X DEL
 - [x] 1.1 `yarn lint` passes locally — 4fb7f4c
 - [x] 1.2 Workflow YAML is well-formed (parses) — 4fb7f4c
 - [x] 1.3 Serve script is executable and syntactically valid (`test -x` + `bash -n`) — 4fb7f4c
-- [ ] 1.4 `lint` check runs and passes on the Phase 1 PR into `development`
+- [x] 1.4 `lint` check runs and passes on the Phase 1 PR into `development` — 4fb7f4c
 
 #### Manual
 
-- [ ] 1.5 Runbook reads as genuinely runnable — each NFR maps to a concrete check
-- [ ] 1.6 PR into `development` opened and reviewed as the final implementation
-- [ ] 1.7 `Vercel` check green on the same PR
+- [x] 1.5 Runbook reads as genuinely runnable — each NFR maps to a concrete check — 4fb7f4c
+- [x] 1.6 PR into `development` opened and reviewed as the final implementation
+- [x] 1.7 `Vercel` check green on the same PR — 4fb7f4c
 
 ### Phase 2: Apply `development` branch protection
 

--- a/context/changes/inspection-gate/plan.md
+++ b/context/changes/inspection-gate/plan.md
@@ -253,9 +253,9 @@ the workflow file and removing the `development` protection rule (`gh api -X DEL
 
 #### Automated
 
-- [x] 1.1 `yarn lint` passes locally
-- [x] 1.2 Workflow YAML is well-formed (parses)
-- [x] 1.3 Serve script is executable and syntactically valid (`test -x` + `bash -n`)
+- [x] 1.1 `yarn lint` passes locally — 4fb7f4c
+- [x] 1.2 Workflow YAML is well-formed (parses) — 4fb7f4c
+- [x] 1.3 Serve script is executable and syntactically valid (`test -x` + `bash -n`) — 4fb7f4c
 - [ ] 1.4 `lint` check runs and passes on the Phase 1 PR into `development`
 
 #### Manual

--- a/context/changes/inspection-gate/research.md
+++ b/context/changes/inspection-gate/research.md
@@ -1,0 +1,250 @@
+---
+date: 2026-07-24T09:02:01Z
+researcher: Claude (opus-4.8)
+git_commit: 8730a60061489e21ca08270f078c787e4ff69ca6
+branch: development
+repository: website-astro
+topic: "F-03 inspection-gate — server-side build/type/lint gate on development + repeatable NFR inspection run"
+tags: [research, ci, branch-protection, vercel, github-actions, nfr, inspection-gate, F-03]
+status: complete
+last_updated: 2026-07-24
+last_updated_by: Claude (opus-4.8)
+---
+
+# Research: F-03 inspection-gate
+
+**Date**: 2026-07-24T09:02:01Z
+**Researcher**: Claude (opus-4.8)
+**Git Commit**: 8730a60061489e21ca08270f078c787e4ff69ca6
+**Branch**: development
+**Repository**: website-astro (GitHub: `Pokerek/website-astro`)
+
+## Research Question
+
+Implement roadmap item **F-03 (`inspection-gate`)**: gate every v1 merge into `development` on
+build, type-check **and lint** via required status checks, and turn the NFR inspection checklist
+behind the guardrails into a repeatable run rather than a memory exercise. `.github/` does not
+exist yet — the workflow is created from scratch and wired as a required status check on
+`development`.
+
+## Summary
+
+- **Build + type-check are already gated server-side by Vercel.** Vercel runs `yarn build`
+  (`astro check && astro build`) on every PR preview; the deploy fails on a type error. The exact
+  GitHub status context Vercel posts today is **`Vercel`** (a legacy commit status). Decision taken:
+  use `Vercel` as (part of) the required check — no new CI for build/types.
+- **The one real gap is `lint`.** Vercel does not run `eslint`, and `.husky/pre-commit`'s
+  lint-staged is `--no-verify`-bypassable, so lint is not gated server-side. Closing it needs a new
+  check source. Recommended: a tiny **lint-only** GitHub Actions workflow (`.github/workflows/inspect.yml`),
+  registered as required check `lint` alongside `Vercel`.
+- **NFR checklist stays manual** (user decision): a checked-in Markdown runbook (`docs/nfr-inspection.md`)
+  plus one 2-line serve script for the no-JS check. Automating the four-engine matrix / Lighthouse /
+  axe in CI is explicitly out of scope — `top_blocker: time`, and the roadmap flags the matrix as
+  not worth automating for a static page.
+- **Ordering is load-bearing.** A required check whose workflow has never reported deadlocks every
+  PR forever. So: merge the workflow into `development` FIRST (it runs, unblocked, because it's not
+  yet required), then declare `lint` (+ `Vercel`) required. This is exactly why F-02 left
+  `development` unprotected.
+- **Admin access confirmed.** Active `gh` account is **`Pokerek`** with **ADMIN** on
+  `Pokerek/website-astro`. `development` currently has **zero** protection (clean slate). Note the
+  repo is under `Pokerek`, NOT `Karol-Chrobok` (the global CLAUDE.md default `gh` account) — that
+  owner 404s. Use the `Pokerek` account for branch-protection API calls.
+
+## Detailed Findings
+
+### 1. Current gate infrastructure (what exists today)
+
+**Server-side gating: none.** No `.github/` directory at all, no workflows/Actions, no `*.yml`
+outside `node_modules`/skills, no `vercel.json`, no `.vercel/`, no `.lighthouserc*`, no
+pa11y/axe/linkinator/Playwright config, no `scripts/` dir, no test runner. Vercel is wired purely
+through the dashboard Git integration (framework inferred from `astro`, package manager from
+`yarn.lock`).
+
+History note: a `.github/instructions/` + `.github/copilot-instructions.md` set existed during F-02
+but was migrated to `.claude/rules/` in commit `4c78c4c` (#16). So `.github/` is now entirely
+absent; F-03 creates it from scratch.
+
+**Local gates (local-only, `--no-verify`-bypassable — none run on a PR):**
+- `.husky/pre-commit`: `npx validate-branch-name` → `npx tsc --noEmit` → `npx lint-staged`
+- `.husky/commit-msg`: `npx --no-install commitlint --edit $1`
+- `commitlint.config.js`: extends `@commitlint/config-conventional`
+- `package.json` `lint-staged`: `src/**/*.{astro,js,jsx,ts,tsx,md}` → `eslint --fix`;
+  `src/**/*.{astro,js,jsx,ts,tsx,json,md,css}` → `prettier --write`
+- `package.json` scripts: `build` = `astro check && astro build`; `lint` = `eslint .`;
+  `lint:fix` = `eslint . --fix`; `format` = `prettier --write "**/*.{...}"`
+- `validate-branch-name.pattern`: `^(main|master|development|(feat|fix|chore|docs)\/[a-zA-Z0-9][a-zA-Z0-9_-]*)$`
+- `eslint.config.js` (flat): `@eslint/js` + `typescript-eslint` + `eslint-plugin-astro` recommended,
+  React jsx-runtime, prettier plugin; custom `simple-import-sort`, `consistent-type-imports`,
+  `no-unused-vars`, `no-console: warn`, padding-before-return.
+- `tsconfig.json`: extends `astro/tsconfigs/strict`. `astro.config.mjs`: static output, React +
+  Tailwind, no adapter.
+
+### 2. GitHub + Vercel ground truth (live, via `gh`)
+
+- **`gh` account:** active is **`Pokerek`** (scopes `repo`, `read:org`, `admin:public_key`, `gist`);
+  `Karol-Chrobok` is logged in but inactive. Repo = **`Pokerek/website-astro`**;
+  `Karol-Chrobok/website-astro` 404s. `viewerPermission: ADMIN`.
+- **Merge settings:** `mergeCommitAllowed:false`, `rebaseMergeAllowed:false`, `squashMergeAllowed:true`,
+  `deleteBranchOnMerge:true`, default branch `development`. (Squash-only.)
+- **`development` protection:** `GET .../branches/development/protection` → **404 Branch not
+  protected**. Zero protection — greenfield.
+- **`main` protection (classic):** `required_pull_request_reviews` present with
+  `required_approving_review_count: 0`, `dismiss_stale_reviews: true`; **`required_status_checks`
+  absent**; `required_linear_history.enabled: true`; `enforce_admins.enabled: false`;
+  `allow_force_pushes.enabled:false`; `allow_deletions.enabled:false`;
+  `required_conversation_resolution.enabled: true`.
+- **Vercel check strings (from recent PRs #16–#18 into development):**
+  - **`Vercel`** — a commit **status** (`state: success`, target_url to the Vercel deployment).
+    This reflects the build/deploy outcome (build + `astro check`). **This is the string to register
+    as required.**
+  - `Vercel Preview Comments` — a check-**run** (app slug `vercel`), preview comments only, NOT a
+    build gate. Do not require it.
+- **No GitHub Actions exist** (`gh run list` empty; `actions/workflows` total_count 0). **No rulesets**
+  (`rulesets` → `[]`); protection is classic branch protection.
+
+### 3. Minimal lint gate — recommended approach
+
+**Option A (dedicated lint-only workflow) — chosen.** Option B (fold lint into Vercel's build via
+`vercel.json`, or rely on husky) is rejected: `vercel.json` is explicitly forbidden by
+release-process.md and couples lint to deploy; husky is bypassable. A ~15-line Actions workflow is
+cheaper and clearer.
+
+**Do NOT run `astro check` in this workflow** — Vercel's `yarn build` already runs it; duplicating
+doubles the job runtime for zero coverage gain. One source of truth per concern: **types = Vercel,
+lint = Actions.**
+
+**Node version:** Astro 5 needs Node 18.20.8 / 20.3 / 22.0+. Astro 6 (upcoming) drops 18/20 and
+requires 22.12+. Pin **Node 22** — valid now, future-proofs the v6 bump. (context7 `/withastro/docs`.)
+
+Proposed `.github/workflows/inspect.yml`:
+
+```yaml
+name: inspect
+
+on:
+  pull_request:
+    branches: [development]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'yarn'
+      - run: yarn install --frozen-lockfile
+      - run: yarn lint
+```
+
+- `cache: 'yarn'` supports Yarn Classic (context7 `/actions/setup-node`); keys off `yarn.lock`.
+- `yarn install --frozen-lockfile` = the fail-if-lockfile-would-change equivalent of `npm ci`.
+- `yarn lint` runs `eslint .` verbatim — no `--fix` (a gate reports, must not mutate). The exposed
+  status-check name is the job id **`lint`**.
+
+### 4. Required-check ordering (deadlock avoidance)
+
+1. Branch `feat/…` off `development`, add `.github/workflows/inspect.yml` (+ NFR runbook + serve
+   script), open PR into `development`. The `lint` check runs for the first time here, unblocked
+   (not yet required). Squash-merge.
+2. THEN add branch protection on `development` requiring status checks **`lint`** and **`Vercel`**.
+   Only checks GitHub has actually observed reporting are valid to require.
+3. From then on every PR into `development` must pass `lint` (Actions) + `Vercel` (build + types).
+
+This is the exact deadlock release-process.md and F-02's plan warned about ("GitHub waits forever on
+a check name that never reports").
+
+### 5. Manual NFR inspection runbook (user decision: manual, not CI)
+
+**Form:** a checked-in Markdown runbook at `docs/nfr-inspection.md`, run once before the
+`development → main` cutover (S-08) and pasted into the cutover PR with boxes ticked. Plus one tiny
+`scripts/nfr-serve.sh` (`yarn build && yarn preview`) that the no-JS + engine checks need.
+
+Mapping the four NFRs (prd.md:220-233) + guardrail (prd.md:96-101) to cheap checks:
+- **NFR-1 Perf (<1s, no CLS):** Chrome DevTools Lighthouse (mobile+desktop) on preview — Perf high,
+  **CLS = 0**, LCP < 1s; Performance panel shows no layout-shift bars; usable <1s on throttled 4G.
+- **NFR-2 A11y (keyboard + SR + WCAG AA):** full Tab-through (reachable, visible focus, logical
+  order, no trap); axe DevTools 0 critical/serious; VoiceOver spot check; contrast ≥ 4.5:1 (3:1 large).
+- **NFR-3 No-JS:** `yarn build && yarn preview`, disable JS + reload → full content, nav works, no
+  blank islands; CLI sanity `curl -s localhost:4321 | grep -c "<main"` > 0.
+- **NFR-4 Cross-engine (4×2):** there are only **3 shipping engines** — Blink (Chrome + Edge),
+  WebKit (Safari + iOS Safari), Gecko (Firefox + Firefox ESR). The runbook states this explicitly so
+  the author doesn't hunt a nonexistent fourth engine. Check layout, fonts, islands, console clean.
+- **Guardrail:** view-source semantic HTML, no TODO/placeholder/lorem, console clean, no 404 links,
+  meta/OG/favicon present.
+
+### 6. What we deliberately do NOT automate
+
+- **Type-check in Actions** — Vercel owns it. **NFR matrix in CI** (Lighthouse CI, axe-core,
+  Playwright, no-JS assertions) — setup+maintenance cost dwarfs value for a solo portfolio;
+  `top_blocker: time`; a runbook run once at cutover is the right altitude (CI'd NFRs = v2 if the
+  site grows). **`push:` trigger / nightly** — the gate is the PR; linting `main` or scheduled runs
+  add noise without extra protection. **Husky as a "gate"** — kept as fast local feedback only,
+  intentionally bypassable, not counted as enforcement.
+
+## Code References
+
+- `package.json:15` — `build`: `astro check && astro build` (Vercel's build; types gated here)
+- `package.json:18` — `lint`: `eslint .` (the command the Actions gate runs)
+- `package.json:22-25` — `lint-staged` (local, bypassable)
+- `.husky/pre-commit`, `.husky/commit-msg` — local gates
+- `eslint.config.js`, `tsconfig.json` (extends `astro/tsconfigs/strict`), `astro.config.mjs`
+- `context/foundation/roadmap.md:52, 81-82, 118-130, 241` — F-03 scope, unknowns, prereqs
+- `context/foundation/prd.md:96-106, 220-233` — Guardrails + the four NFRs
+- `.claude/rules/release-process.md:43-64` — repository constraints + local gates (authoritative)
+- `context/foundation/tasks-linear.md:39` — tracker row **CHR-30** (F-03, currently Backlog)
+
+## Architecture Insights
+
+- **Separation of concerns per check:** Vercel = build + types (already free), Actions = lint (the
+  only gap). Avoid duplicating `astro check` in Actions.
+- **The gate is the PR into `development`.** No `push`/nightly triggers. Squash-only merges mean the
+  required checks run on the PR head; `development` protection is the enforcement point (F-03), `main`
+  is already protected separately.
+- **Vercel `Vercel` context is a commit status, not a check-run** — both are requirable by name;
+  register `Vercel`.
+- **Two-step deploy of the gate itself** (workflow lands unprotected → then required) is mandatory,
+  not stylistic — it's the only way to avoid the never-reports deadlock.
+
+## Historical Context (from prior changes — F-02)
+
+- `context/archive/2026-07-23-v1-release-staging/plan.md:67-68, 288-289` — F-02 explicitly left
+  `development` unprotected and no CI, naming F-03 as owner of "CI gating and `development` branch
+  protection", with the same never-reports deadlock rationale.
+- `context/archive/2026-07-23-v1-release-staging/plan-brief.md:26, 34, 60` — decision table:
+  "Protection on `development` | None — harden `main` only | F-03 will add protection when it has
+  status checks to attach."
+- `context/archive/2026-07-23-v1-release-staging/change.md:36-41` — recorded live protection state:
+  `main` protected, `development` 404 (intended until F-03). Matches this research's live findings.
+- `context/archive/2026-07-23-v1-release-staging/change.md:65-70` — Vercel Preview Deployment
+  Protection (SSO) is ON; preview URLs `302` to `vercel.com/sso-api`. A CI job cannot anonymously
+  fetch a preview — the NFR runbook therefore targets a LOCAL build (`yarn preview`) for the no-JS /
+  engine checks, and a logged-in browser for the Lighthouse/axe steps.
+- `context/archive/2026-07-23-v1-release-staging/change.md:77-102` — **`prettier --check "**/*.md"`
+  false-pass debt:** ~20 markdown files fail `prettier --check` (printWidth 120) because prettier
+  isn't wired for repo-wide `.md`. Consequence for F-03: **do NOT add a repo-wide `prettier --check`
+  to the workflow** — it would fail on pre-existing files. The chosen lint-only (`eslint .`) gate
+  sidesteps this.
+
+## Open Questions
+
+- **Should `development` protection also set `required_pull_request_reviews` (0 approvals, PR
+  required) to mirror `main`, or only required status checks?** The roadmap outcome only asks for the
+  build/type/lint gate; adding a PR requirement on `development` is a small extra that matches `main`'s
+  posture. Decide in planning. (Leaning: require status checks + PR, 0 approvals, `strict` off to
+  avoid forced rebases on squash-only.)
+- **`enforce_admins` on `development`?** `main` has it off. Keeping it off lets the author bypass in a
+  pinch; keeping parity with `main` is simplest. Decide in planning.
+- **`strict` (require branches up to date before merge)?** With squash-only + a fast-moving solo repo,
+  `strict: true` forces a rebuild on every base change. Lean `strict: false`.
+
+## Related Research
+
+- None prior for this change. Upstream context: `context/archive/2026-07-23-v1-release-staging/`
+  (F-02, the prerequisite) and `context/foundation/roadmap.md` §F-03.
+
+## Tracker
+
+- Linear-only (no GitHub-issues mirror): **CHR-30 · F-03 · inspection-gate · "Inspection gate" ·
+  Backlog** (`context/foundation/tasks-linear.md:39`). `/pr-ready` → In Review, `/pr-merge` → Done.

--- a/context/changes/inspection-gate/reviews/impl-review-phase-1.md
+++ b/context/changes/inspection-gate/reviews/impl-review-phase-1.md
@@ -1,0 +1,45 @@
+<!-- IMPL-REVIEW-REPORT -->
+# Implementation Review: F-03 Inspection Gate
+
+- **Plan**: context/changes/inspection-gate/plan.md
+- **Scope**: Phase 1 of 2
+- **Date**: 2026-07-24
+- **Verdict**: APPROVED (with 2 minor warnings, both fixed)
+- **Findings**: 0 critical, 1 warning, 1 observation
+
+## Verdicts
+
+| Dimension | Verdict |
+|-----------|---------|
+| Plan Adherence | PASS |
+| Scope Discipline | PASS |
+| Safety & Quality | WARNING |
+| Architecture | PASS |
+| Pattern Consistency | WARNING |
+| Success Criteria | PASS (1.1–1.3 pass; 1.4–1.7 PR-dependent, pending) |
+
+## Findings
+
+### F1 — Workflow lacks least-privilege permissions
+
+- **Severity**: ⚠️ WARNING
+- **Impact**: 🏃 LOW — quick decision; fix is obvious and narrowly scoped
+- **Dimension**: Safety & Quality
+- **Location**: .github/workflows/inspect.yml:1
+- **Detail**: No `permissions:` block, so GITHUB_TOKEN inherited the repo default (can be read/write for same-repo PRs). A lint-only job needs only read; least-privilege is the CI hardening default and fits the "survives inspection" guardrail.
+- **Fix**: Add top-level `permissions:\n  contents: read`.
+- **Decision**: FIXED via Fix now — added `permissions: contents: read`.
+
+### F2 — Actions pinned to @v6 while @v7 is current
+
+- **Severity**: 🔷 OBSERVATION
+- **Impact**: 🏃 LOW — quick decision; fix is obvious and narrowly scoped
+- **Dimension**: Pattern Consistency
+- **Location**: .github/workflows/inspect.yml:11,12
+- **Detail**: `actions/checkout@v6` and `actions/setup-node@v6` resolve and work (v6 major tags confirmed), but current major is v7 (checkout v7.0.1, setup-node v7.0.0). For a brand-new workflow, matching latest is cleaner. Not broken — purely currency.
+- **Fix**: Bump both to @v7.
+- **Decision**: FIXED via Fix now — bumped checkout and setup-node to @v7 (v7 major tags confirmed to exist).
+
+## Notes
+
+- change.md kept at `status: implementing` (not `impl_reviewed`): this is a phase-scoped review at Phase 1 of 2, with Phase 1's PR-dependent items (1.4–1.7) still pending and Phase 2 not started. Advancing to `impl_reviewed` now would misstate the change state.

--- a/docs/nfr-inspection.md
+++ b/docs/nfr-inspection.md
@@ -1,0 +1,67 @@
+# v1 NFR Inspection Runbook
+
+Run this once before the `development → main` cutover (roadmap S-08). Paste the checklist into the
+cutover PR and tick every box. Target the Vercel `development` preview URL unless a step says
+"local build".
+
+The four NFRs are outside-observable properties — they are what an inspecting tech lead actually
+measures, and together they are the "site survives a technical inspection" guardrail
+(`context/foundation/prd.md:96-106, 220-233`).
+
+## Prep
+
+- [ ] Deploy is green on the `development` preview
+- [ ] `yarn build && yarn preview` runs clean locally — or run `scripts/nfr-serve.sh`
+      (needed for the no-JS and cross-engine checks, which require the built `dist/`)
+
+## NFR-1 — Performance: first paint < 1s, no layout shift
+
+- [ ] Chrome DevTools → Lighthouse (run Mobile **and** Desktop) on the preview URL:
+      Performance high, **CLS = 0**, LCP < 1s
+- [ ] DevTools → Performance panel: record a load, confirm no layout-shift bars
+- [ ] Network throttled to "Fast 4G": content is readable in under a second
+
+## NFR-2 — Accessibility: keyboard + screen reader + WCAG-AA contrast
+
+- [ ] Tab through the entire page: every interactive element is reachable, has a visible focus
+      ring, follows a logical order, and there is no keyboard trap
+- [ ] axe DevTools (browser extension) scan: 0 critical / serious violations
+- [ ] VoiceOver (Cmd+F5) spot check: headings, links, and any control announce meaningful names
+- [ ] Contrast: axe covers most of it; manually confirm any custom fg/bg pair meets ≥ 4.5:1
+      (3:1 for large text)
+
+## NFR-3 — No-JS availability
+
+- [ ] `yarn build && yarn preview` (or `scripts/nfr-serve.sh`)
+- [ ] DevTools → Command Palette → "Disable JavaScript", reload: full content renders, nav links
+      work, no blank islands
+- [ ] CLI sanity: `curl -s localhost:4321 | grep -c "<main"` returns > 0, and key headings/links
+      are present in the raw HTML
+
+## NFR-4 — Cross-engine: latest two versions of the mainstream engines
+
+There are only **three shipping browser engines** — "4 engines × 2 versions" is satisfied by testing
+current + previous of each. Do not burn time hunting a nonexistent fourth engine. Automating the
+full matrix is deliberately out of scope (see the note below).
+
+- [ ] **Blink** — Chrome (current) and Edge (current Chromium)
+- [ ] **WebKit** — Safari (current, desktop) and Safari on iOS (current)
+- [ ] **Gecko** — Firefox (current) and Firefox ESR (the "previous" line)
+- [ ] For each: layout intact, fonts load, interactive islands work, no console errors
+
+## Guardrail — "survives a technical inspection"
+
+- [ ] View source: semantic HTML; no leaked TODO / placeholder / lorem text
+- [ ] Console is clean (no errors or warnings) across every engine above
+- [ ] All links resolve (no 404s); external links carry the intended `rel` / `target`
+- [ ] Meta / OpenGraph tags and favicon are present
+
+---
+
+## What this runbook deliberately does NOT automate, and why
+
+`top_blocker: time`. For a solo static portfolio the setup and maintenance cost of CI-automating
+these NFRs dwarfs their value — a checklist run once at the cutover is the right altitude.
+Automating the perf budget (Lighthouse CI), a11y (axe-core), no-JS assertions, and the cross-engine
+matrix (Playwright) is a v2 concern if the site grows. The automated gate on `development` covers
+build + type-check (Vercel) and lint (GitHub Actions); these NFRs are the manual complement.

--- a/scripts/nfr-serve.sh
+++ b/scripts/nfr-serve.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# scripts/nfr-serve.sh — build once, serve the static output for NFR inspection.
+# Used by docs/nfr-inspection.md for the no-JS and cross-engine checks, which need
+# the built dist/ rather than the dev server. Serves on http://localhost:4321.
+set -euo pipefail
+
+yarn build
+yarn preview


### PR DESCRIPTION
## Summary

Roadmap **F-03 (`inspection-gate`)** — gate every merge into `development` on build, type-check and lint, and make the NFR inspection a repeatable run.

- **Lint gate (the one server-side gap):** new `.github/workflows/inspect.yml` runs `yarn lint` on every PR into `development`. Build + type-check are already gated by Vercel (`yarn build` = `astro check && astro build`); this closes the eslint gap Vercel doesn't cover.
- **Hardened workflow:** least-privilege `permissions: contents: read`, Node 22, `yarn install --frozen-lockfile`, actions pinned to current major `@v7`.
- **Manual NFR runbook:** `docs/nfr-inspection.md` maps all four NFRs + the "survives a technical inspection" guardrail to concrete checks, plus `scripts/nfr-serve.sh` (build + serve `dist/`) for the no-JS / cross-engine steps. Manual by design — automating the matrix isn't worth it for a static page (`top_blocker: time`).
- Includes the F-03 change folder (research, plan, brief, phase-1 review).

## Test plan

- [ ] `lint` check passes on this PR (the gate linting itself)
- [ ] `Vercel` check green (build + `astro check`)
- [ ] `docs/nfr-inspection.md` reads as a genuinely runnable checklist

## Follow-up (not in this PR)

After this squash-merges, **Phase 2** applies branch protection on `development` requiring `lint` + `Vercel`. Ordering is deliberate: requiring `lint` before it has ever reported would deadlock every PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)