### PR TITLE
chore: rename project to chrobok-dev-website

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# website-astro
+# chrobok-dev-website
 
 Personal site at https://www.chrobok.dev. Astro 5 + React 18 islands, Tailwind 3, shadcn/ui, TypeScript 5.
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# website-astro
+# chrobok-dev-website
 Private website write in Astro

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "website-astro",
+  "name": "chrobok-dev-website",
   "type": "module",
   "version": "0.0.1",
   "packageManager": "yarn@1.22.22",


### PR DESCRIPTION
## Summary
Renames the project from `website-astro` to `chrobok-dev-website`, matching the GitHub repo rename (`Pokerek/website-astro` → `Pokerek/chrobok-dev-website`, redirects in place).

Text changes (active files only):
- `package.json` — `name` field
- `README.md` — heading
- `CLAUDE.md` — heading

### Deliberately left unchanged
- `.claude/rules/release-process.md` Vercel preview URL (`website-astro-git-development-…vercel.app`) — derives from the **Vercel project name**, not the repo. Stays valid until the Vercel project is renamed in its dashboard (external step).
- `context/archive/**` historical snapshots — left as-is; GitHub redirects keep old `Pokerek/website-astro` URLs working.

## Test plan
- [ ] Vercel branch preview builds (`astro check && astro build`)
- [ ] Repo redirect from old name resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)