### PR TITLE
chore: sync Linear state snapshot for F-01 and F-03 to Done

### DIFF
--- a/context/foundation/tasks-linear.md
+++ b/context/foundation/tasks-linear.md
@@ -34,9 +34,9 @@ is a point-in-time snapshot — Linear is the live source of truth for workflow 
 
 | Linear | Roadmap ID | Change ID                 | Title (short)                    | State snapshot |
 | ------ | ---------- | ------------------------- | -------------------------------- | -------------- |
-| CHR-28 | F-01       | design-system-contract    | Design-system & layout contract  | In Review      |
+| CHR-28 | F-01       | design-system-contract    | Design-system & layout contract  | Done           |
 | CHR-29 | F-02       | v1-release-staging        | v1 release staging               | Done           |
-| CHR-30 | F-03       | inspection-gate           | Inspection gate                  | Backlog        |
+| CHR-30 | F-03       | inspection-gate           | Inspection gate                  | Done           |
 | CHR-31 | S-01       | hero-first-screen         | Hero — first screen              | Backlog        |
 | CHR-32 | S-02       | work-proof-block          | Work — proof block               | Backlog        |
 | CHR-33 | S-03       | skills-two-tier           | Skills — two tiers               | Backlog        |


### PR DESCRIPTION
## Summary

Aligns the point-in-time **State snapshot** column in `context/foundation/tasks-linear.md` with the live Linear tracker.

- **CHR-28** (F-01 `design-system-contract`): snapshot said `In Review` → now `Done`
- **CHR-30** (F-03 `inspection-gate`): snapshot said `Backlog` → now `Done`

Both issues were merged (PR #17, PR #19) and are already `Done` in Linear — `/pr-merge` moved them at merge time. Only the doc snapshot had drifted. No Linear writes needed.

CHR-29 (F-02) was already `Done` in the snapshot; unchanged.

## Test plan

- Docs-only change; no code affected.
- Verified live Linear state for CHR-28 / CHR-30 / CHR-29 = `Done` via the Linear MCP before editing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)