### PR TITLE
docs: keep constants and types out of astro frontmatter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,15 @@ When the structure changes, update this section.
     componentName.test.tsx   # tests (optional)
   ```
 - Compound components are namespaced: `ComponentName.SubComponentName`.
+- **Feature components keep data and types out of the `.astro` file.** Module-scope constants go in a
+  sibling `componentName.constants.ts`, types in `componentName.types.ts`. The `.astro` frontmatter
+  should import and render — not declare the content it renders.
+  ```
+  skills/
+    Skills.astro             # markup, imports its data
+    skills.constants.ts      # SKILL_CATEGORIES, TIER_LEGEND, …
+    skills.types.ts          # Tier, SkillCategory, …
+  ```
 
 ## Naming
 

--- a/context/changes/astro-constants-extraction/change.md
+++ b/context/changes/astro-constants-extraction/change.md
@@ -1,0 +1,33 @@
+---
+change_id: astro-constants-extraction
+title: Extract .astro constants and types into sibling files
+status: new
+created: 2026-07-27
+updated: 2026-07-27
+archived_at: null
+---
+
+## Notes
+
+Extract module-scope constants and types out of feature `.astro` frontmatter into sibling
+`componentName.constants.ts` / `componentName.types.ts` files, per the CLAUDE.md Architecture
+convention added alongside this change.
+
+Known targets (as of 2026-07-27, after S-03 lands):
+
+| File | In frontmatter today |
+| --- | --- |
+| `src/components/skills/Skills.astro` | `Tier`, `TIER_VARIANT`, `TIER_LEGEND`, `SKILL_CATEGORIES` — ~85 lines of data |
+| `src/components/work/SologyRole.astro` | `STACK_TIERS` |
+| `src/components/work/MeetmediaRole.astro` | `STACK_CAPTION_ID`, `STACK` |
+| `src/components/hero/Hero.astro` | `EMAIL`, `CV_PATH`, `CV_FILENAME` |
+| `src/components/about/About.astro` | `JOURNAL_URL` |
+| `src/components/footer/Footer.astro` | 1 constant |
+
+Open question to settle at planning time: does the convention cover the `interface Props` that every
+`.astro` component with props declares (`src/components/layout/Section.astro:13`), or only domain types
+and content constants? `Section.astro`'s `const { id } = Astro.props` and `hasLabel` are runtime locals
+and stay in frontmatter either way.
+
+Depends on S-03 (`skills-two-tier`, PR #25) being merged — `Skills.astro` is the largest target and is
+still in review.


### PR DESCRIPTION
## Summary

- Records a convention under `CLAUDE.md` → Architecture: feature `.astro` components keep module-scope constants in a sibling `componentName.constants.ts` and types in `componentName.types.ts`. The `.astro` frontmatter should import and render, not declare the content it renders.
- Opens `context/changes/astro-constants-extraction/` to track applying it to the six components that predate the rule — `Skills.astro` (~85 lines of data in frontmatter), `SologyRole`, `MeetmediaRole`, `Hero`, `About`, `Footer`.

Docs only — no source files change, so nothing here affects the rendered site.

## Open question for the follow-up

Whether the convention covers the `interface Props` every `.astro` component with props declares (`Section.astro:13`), or only domain types and content constants. Left for planning time rather than decided here. `Section.astro`'s `const { id } = Astro.props` and `hasLabel` are runtime locals and stay in frontmatter either way.

## Test plan

- [ ] `yarn build` and `yarn lint` pass (unchanged — no source files touched)
- [ ] `CLAUDE.md` renders correctly on GitHub and the example tree reads clearly

🤖 Generated with [Claude Code](https://claude.com/claude-code)