### PR TITLE
fix: mobile nav menu not closing after click

### DIFF
--- a/src/components/navigation/Navigation.astro
+++ b/src/components/navigation/Navigation.astro
@@ -45,12 +45,12 @@ import { NAV_ITEMS, WORDMARK } from './navigation.constants';
   // eslint-disable-next-line prettier/prettier
   const menu = document.getElementById('nav-disclosure');
 
-  if (!menu) return;
+  if (menu) {
+    const close = () => menu.removeAttribute('open');
 
-  const close = () => menu.removeAttribute('open');
-
-  menu.addEventListener('click', (e) => e.target.closest('a') && close());
-  document.addEventListener('click', (e) => {
-    if (menu.hasAttribute('open') && !menu.contains(e.target)) close();
-  });
+    menu.addEventListener('click', (e) => e.target.closest('a') && close());
+    document.addEventListener('click', (e) => {
+      if (menu.hasAttribute('open') && !menu.contains(e.target)) close();
+    });
+  }
 </script>


### PR DESCRIPTION
## Summary
- The previous commit (`e5149e3`) added `if (!menu) return;` inside the non-module `<script is:inline>` in `Navigation.astro`. A top-level `return` in a classic script is a `SyntaxError`, which silently killed the entire script — so neither the link-click nor outside-click handler ever attached, and the mobile menu never closed.
- Replaced the early `return` with an `if (menu) { ... }` block wrapping the same logic.

## Test plan
- [x] Reproduced the `SyntaxError: Illegal return statement` in the browser console on `development`
- [x] Confirmed the error disappears after the fix
- [x] Opened the mobile menu and clicked a nav link — menu closes
- [x] Opened the mobile menu and clicked outside it — menu closes
- [x] `yarn build` (includes `astro check`) passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)